### PR TITLE
Add: build.bat for building on windows

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,15 @@
+::
+:: cleaning the build dir
+sencha ant clean
+
+:: building the app
+sencha app build
+
+:: get additional stuff for exist-db
+call ant build-plus
+
+:: build xar
+chdir .\build
+call ant
+
+chdir ..


### PR DESCRIPTION
The build process was supported on linux shell based systems via the build.sh script. This script runs all reqwuired commands. On Windows one had to run all respective commands manually.

This feature adds a coresponding build.bat for Windows.