### PR TITLE
Fix duplicate template for mei:geogName

### DIFF
--- a/add/data/xslt/meiHead2HTML.xsl
+++ b/add/data/xslt/meiHead2HTML.xsl
@@ -864,9 +864,6 @@
             </xsl:element>
         </xsl:for-each>
     </xsl:template>-->
-    <xsl:template match="geogName" mode="valueOnly">
-        <xsl:apply-templates select="node()"/>
-    </xsl:template>
     <xsl:template match="langUsage">
         <xsl:element name="div">
             <xsl:attribute name="class">property</xsl:attribute>


### PR DESCRIPTION
getHeader.xql would fail for MEI-files due to ambiguous rule match for
Mei:geogName

fixes #94