### PR TITLE
SVG for annotations added

### DIFF
--- a/add/data/xql/getAnnotationsOnPage.xql
+++ b/add/data/xql/getAnnotationsOnPage.xql
@@ -1,4 +1,4 @@
-xquery version "1.0";
+xquery version "3.0";
 (:
   Edirom Online
   Copyright (C) 2011 The Edirom Project
@@ -38,8 +38,7 @@ declare namespace request="http://exist-db.org/xquery/request";
 declare namespace ft="http://exist-db.org/xquery/lucene";
 declare namespace xmldb="http://exist-db.org/xquery/xmldb";
 
-(:declare option exist:serialize "method=text media-type=text/plain omit-xml-declaration=yes";:)
-(:declare option exist:serialize "method=xhtml media-type=text/html omit-xml-declaration=yes indent=yes";:)
+declare option exist:serialize "method=text media-type=text/plain omit-xml-declaration=yes";
 
 declare function local:getAnnotations($uriSharp as xs:string, $surfaceId as xs:string, $annotations as element()*, $elems as element()*) as xs:string* {
     for $annotation in $annotations
@@ -49,8 +48,8 @@ declare function local:getAnnotations($uriSharp as xs:string, $surfaceId as xs:s
 	let $cat := $annotation/mei:ptr[@type="categories"]/replace(@target, '#', '')
 	let $plist := for $p in tokenize($annotation/@plist, '\s+')
 					return if(starts-with($p, $uriSharp))then(substring-after($p, $uriSharp))else()
+    let $svgList := local:getAnnotSVGs($id, $plist, $elems)
     let $plist := local:getParticipants($id, $plist, $elems)
-    let $svgList := local:getAnnotSVGs(concat($uriSharp, $surfaceId), $annotation)
 	return
 		concat('
        	{',
@@ -70,14 +69,14 @@ declare function local:getAnnotations($uriSharp as xs:string, $surfaceId as xs:s
     @param $elems The elements to check (most likely measures and zones)
     @returns A sequence of annotation elements
 :)
-declare function local:findAnnotations($uri as xs:string, $elemIds as xs:string*) as element()* {
+declare function local:findAnnotations($edition as xs:string, $uri as xs:string, $elemIds as xs:string*) as element()* {
 
     (: TODO: search in other documents and in other collections :)
     (: TODO: check if annotations hold URIs or IDRefs :)
 	functx:distinct-deep(
 		for $id in $elemIds
-		let $query := <query><term>{concat($uri, '#', $id)}</term></query>
-		return collection(eutil:getPreference('edition_path', request:get-parameter('edition', '')))//mei:annot/@plist[tokenize(string(.), '\s+') = concat($uri, '#', $id)]/..
+		let $uriPlusId := concat($uri, '#', $id)
+		return collection(eutil:getPreference('edition_path', $edition))//mei:annot/@plist[tokenize(string(.), '\s+') = $uriPlusId]/..
 	)
 };
 
@@ -109,19 +108,20 @@ declare function local:getParticipants($annoId as xs:string, $plist as xs:string
     @param $elem A sequence of elements which could be relevant
     @returns A JSON representation of the perticipants
 :)
-declare function local:getAnnotSVGs($surfaceUri as xs:string, $anno as element()) as xs:string {
+declare function local:getAnnotSVGs($annoId as xs:string, $plist as xs:string*, $elems as element()*) as xs:string {
 
-    let $annoId := $anno/string(@xml:id)
-    let $figs := $anno//mei:graphic[@target = $surfaceUri]/..
+    let $participants := $elems[@id = $plist]
     return
-        string-join(
-            for $fig in $figs
-            let $fig := string($fig/@xml:id)
-            let $xslInstruction := $fig/svg:svg
-            let $ser := util:serialize($xslInstruction, ())
-            let $repl := replace(replace($ser, '"', '\\"'), '\n', '')
-            return 
-		        concat('{id:"', $annoId, '__', $fig, '",svg:"', $repl,'"}'), ",")
+        
+    string-join(
+    
+        for $svg in $participants
+        let $id := $svg/@id
+        let $ser := util:serialize($svg, ())
+        let $repl := replace(replace($ser, '"', '\\"'), '\n', '')
+        return concat('{id:"', $annoId, '__', $id, '",svg:"', $repl,'"}')
+    
+    , ', ')
 };
 
 (:~
@@ -132,10 +132,12 @@ declare function local:getAnnotSVGs($surfaceUri as xs:string, $anno as element()
 :)
 declare function local:getCoordinates($participant as element()) as xs:integer+ {
     let $zone := if(name($participant) = 'measure' or name($participant) = 'staff') then($participant/root()/id(substring($participant/@facs, 2))) else($participant)
-    return
+    return if($zone/@ulx) then(
         (number($zone/@ulx), number($zone/@uly), number($zone/@lrx), number($zone/@lry))
+    )else ((-1, -1, -1, -1))
 };
 
+let $edition := request:get-parameter('edition', '')
 let $uri := request:get-parameter('uri', '')
 let $uriSharp := concat($uri, '#')
 let $mei := doc($uri)/root()
@@ -148,18 +150,17 @@ let $measureLike :=
     for $id in $zones[@type = 'measure' or @type = 'staff']/string(@xml:id)
 	let $ref := concat('#', $id)
 	return $mei//*[@facs = $ref]
+	
+let $svgLike := $surface//svg:svg
 
-let $targetLike := $zones | $measureLike
+let $targetLike := $zones | $measureLike | $svgLike
+let $targetLikeIds := $zones/@xml:id | $measureLike/@xml:id | $svgLike/@id
 
-
-let $annotations := local:findAnnotations($uri, $targetLike/@xml:id)
-
-let $annots := collection('/db/contents')//mei:annot[matches(@plist, $uri)] | $mei//mei:annot
-let $test := local:getAnnotations($uriSharp, $surfaceId, $annots, $targetLike)
+let $annotations := local:findAnnotations($edition, $uri, $targetLikeIds)
+let $annots := local:getAnnotations($uriSharp, $surfaceId, $annotations, $targetLike)
 
 return (
     concat('[',
-	    string-join($test, ','),
+	    string-join($annots, ','),
     ']')
 )
-

--- a/app/controller/window/source/SourceView.js
+++ b/app/controller/window/source/SourceView.js
@@ -202,24 +202,26 @@ Ext.define('EdiromOnline.controller.window.source.SourceView', {
 			
 			var pageId = view.getActivePage().get('id');
 			
-			Ext.Ajax.request({
-				url: 'data/xql/getAnnotationsOnPage.xql',
-				method: 'GET',
-				params: {
-					uri: view.uri,
-					pageId: pageId
-				},
-				success: function (response) {
-					var data = response.responseText;
-					
-					var annotations = Ext.create('Ext.data.Store', {
-						fields:[ 'id', 'title', 'text', 'uri', 'plist', 'svgList', 'priority', 'categories', 'fn'],
-						data: Ext.JSON.decode(data)
-					});
-					
-					me.annotationsLoaded(annotations, view, pageId);
-				}
-			});
+			
+			window.doAJAXRequest('data/xql/getAnnotationsOnPage.xql',
+                'GET', 
+                {
+                    uri: view.uri,
+                    pageId: pageId
+                },
+                Ext.bind(function(response){
+                    var me = this;
+                    var data = response.responseText;
+
+                    var annotations = Ext.create('Ext.data.Store', {
+                        fields: ['id', 'title', 'text', 'uri', 'plist', 'svgList', 'priority', 'categories', 'fn'],
+                        data: Ext.JSON.decode(data)
+                    });
+
+                    me.annotationsLoaded(annotations, view, pageId);
+                }, this)
+            );
+			
 		} else {
 			view.hideAnnotations();
 		}


### PR DESCRIPTION
Besides SVG for overlays, now there is support for SVG for annotations.

@bwbohl and @nikobeer could you please check, if this works with existing editions?

In the MEI source file put an SVG into an `<surface>` element:

```xml
<surface` n="1" xml:id="facsimile-0102001">
    <graphic target="image.jpg" type="facsimile" width="3780" height="2952"/>
    <svg id="svg-annotation-100002" xmlns="http://www.w3.org/2000/svg" fill="none" width="3780"
                        height="2952" viewBox="0 0 3780 2952" style="fill:none">
         <rect x="2646" y="1350" fill="red" fill-opacity="0.3" stroke="red" width="66" height="87"/>
    </svg>
</surface>
```

In the MEI work file add an annotation as follows:

```xml
<annot xml:id="annotation-100002" type="editorialComment" plist="xmldb:exist:///db/apps/.../source.xml#svg-annotation-100002">
    <title>SVG Annotation</title>
    <p>SVG Annotation</p>
    <ptr type="priority" target="#ediromAnnotPrio1"/>
    <ptr type="categories" target=""/>
</annot>
```
  