### PR TITLE
Features from Beethoves-Werkstatt

### DIFF
--- a/add/data/xqm/source.xqm
+++ b/add/data/xqm/source.xqm
@@ -64,7 +64,16 @@ declare function source:getLabels($sources as xs:string*, $edition as xs:string)
 declare function source:getLabel($source as xs:string, $edition as xs:string) as xs:string {
     
     let $language := eutil:getLanguage($edition)
-    return doc($source)//mei:source/mei:titleStmt/data(mei:title[not(@xml:lang) or @xml:lang = $language])
+    let $label := doc($source)//mei:source/mei:titleStmt/mei:title[not(@xml:lang) or @xml:lang = $language]
+    let $label := if($label)
+                    then($label)
+                    else(doc($source)//mei:meiHead/mei:fileDesc/mei:titleStmt/mei:title[not(@xml:lang) or @xml:lang = $language])
+    let $label := if($label)
+                    then($label)
+                    else('unknown title')
+    return
+        string($label)
+
 };
 
 (:~

--- a/app/Application.js
+++ b/app/Application.js
@@ -61,9 +61,8 @@ Ext.define('EdiromOnline.Application', {
         'EdiromOnline.view.desktop.App'
     ],
     
-    //TODO:
-    activeEdition: 'xmldb:exist:///db/contents/h-moll/edition.xml',
-   /* activeWork: 'edirom_work_743373fb-4dcf-4329-90c0-fd1eacc9ea69', */
+    activeEdition: '',
+    activeWork: '',
 
     launch: function() {
         var me = this;

--- a/app/view/desktop/TaskBar.js
+++ b/app/view/desktop/TaskBar.js
@@ -62,7 +62,7 @@ Ext.define('EdiromOnline.view.desktop.TaskBar', {
             me.windowSort,
             me.globalTools,
             //me.desktopSwitch,
-            //me.quickStart,
+            me.quickStart,
             {
                 xtype: 'splitter', html: '&#160;',
                 height: 14, width: 2, // TODO - there should be a CSS way here


### PR DESCRIPTION
* search for edition and work
* alternatively get source labels from different xpath, but always return a string
* reactivate concordance navigator

all seem plausible to me