### PR TITLE
fix call to util:serialize

### DIFF
--- a/add/data/xql/getAnnotationsOnPage.xql
+++ b/add/data/xql/getAnnotationsOnPage.xql
@@ -117,7 +117,7 @@ declare function local:getAnnotSVGs($annoId as xs:string, $plist as xs:string*, 
     
         for $svg in $participants
         let $id := $svg/@id
-        let $ser := util:serialize($svg, ())
+        let $ser := fn:serialize($svg, ())
         let $repl := replace(replace($ser, '"', '\\"'), '\n', '')
         return concat('{id:"', $annoId, '__', $id, '",svg:"', $repl,'"}')
     

--- a/add/data/xql/getReducedDocument.xql
+++ b/add/data/xql/getReducedDocument.xql
@@ -41,7 +41,7 @@ let $doc := transform:transform($doc, $xsl, <parameters><param name="selectionId
 let $doc := $doc/root()
 
 let $xslInstruction := $doc//processing-instruction(xml-stylesheet)
-let $xslInstruction := for $i in util:serialize($xslInstruction, ())
+let $xslInstruction := for $i in fn:serialize($xslInstruction, ())
                         return
                         if(matches($i, 'type="text/xsl"'))
                         then(substring-before(substring-after($i, 'href="'), '"'))


### PR DESCRIPTION
Before this commit the deprecated exist function util:serialize was called. Theses calls now have been replaced by a call to the standard function fn:serialize.
Closes #135w