### PR TITLE
Fix get concordance

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -1,4 +1,4 @@
-name: Docker Image CI
+name: Docker build PR
 
 on:
 #  push:
@@ -18,21 +18,21 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Build Edirom Online from bazga-dev
+    - name: Build Edirom Online from ${{ env.GITHUB_REF }}
       run: docker run --rm -v `pwd`:/app -w /app --entrypoint ./build.sh bwbohl/sencha-cmd
     - uses: actions/upload-artifact@v2
       with:
-        name: EdiromOnline.xar
-        path: build-xar/EdiromOnline.xar
+        name: EdiromOnline_${{ env.GITHUB_REF }}.xar
+        path: build-xar/EdiromOnline*.xar
         if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn`
 
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: deploy
-        uses: jaapio/keelsh-deploy@master
-        with:
-          keelBaseUrl: http://keel.euryanthe.de
-          image: 'bazga/existdb'
-          tag: 'latest'
+#  deploy:
+#    needs: build
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: deploy
+#        uses: jaapio/keelsh-deploy@master
+#        with:
+#          keelBaseUrl: http://keel.euryanthe.de
+#          image: 'bazga/existdb'
+#          tag: 'latest'

--- a/add/data/xqm/util.xqm
+++ b/add/data/xqm/util.xqm
@@ -143,7 +143,7 @@ declare function eutil:getLanguageString($key as xs:string, $values as xs:string
 };
 
 (:~
-: Returns a language specific string
+: Returns a language specific string from the locale/edirom-lang files
 :
 : @param $key The key to search for
 : @param $values The values to include into the string

--- a/add/data/xqm/util.xqm
+++ b/add/data/xqm/util.xqm
@@ -47,8 +47,6 @@ declare namespace edirom="http://www.edirom.de/ns/1.3";
 :)
 
 declare function eutil:getLocalizedName($node, $lang) as xs:string {
-  let $nodeName := local-name($node)
-  return
     if ($node/mei:title)
     then (
         if ($lang = $node/mei:title/@xml:lang)
@@ -176,7 +174,6 @@ declare function eutil:getPreference($key as xs:string, $edition as xs:string?) 
      return    
         if($projectFile != 'null' and $projectFile//entry[@key = $key]) then ($projectFile//entry[@key = $key]/string(@value))
         else ($file//entry[@key = $key]/string(@value))
-     
 };
 
 (:~

--- a/add/data/xqm/util.xqm
+++ b/add/data/xqm/util.xqm
@@ -47,6 +47,7 @@ declare namespace edirom="http://www.edirom.de/ns/1.3";
 :)
 
 declare function eutil:getLocalizedName($node, $lang) as xs:string {
+
     if ($node/mei:title)
     then (
         if ($lang = $node/mei:title/@xml:lang)
@@ -75,6 +76,7 @@ declare function eutil:getLocalizedName($node, $lang) as xs:string {
 : @return The document
 :)
 declare function eutil:getDoc($uri) {
+
     if(starts-with($uri, 'textgrid:'))
     then(
         let $session := request:get-cookie-value('edirom_online_textgrid_sessionId')
@@ -93,6 +95,7 @@ declare function eutil:getDoc($uri) {
 : @return The labels
 :)
 declare function eutil:getDocumentsLabels($docs as xs:string*, $edition as xs:string) as xs:string {
+
     string-join(
         eutil:getDocumentsLabelsAsArray($docs, $edition)
     , ', ')
@@ -105,7 +108,10 @@ declare function eutil:getDocumentsLabels($docs as xs:string*, $edition as xs:st
 : @return The labels
 :)
 declare function eutil:getDocumentsLabelsAsArray($docs as xs:string*, $edition as xs:string) as xs:string* {
-    for $doc in $docs return eutil:getDocumentLabel($doc, $edition)
+
+    for $doc in $docs
+    return
+        eutil:getDocumentLabel($doc, $edition)
 };
 
 (:~
@@ -191,5 +197,4 @@ declare function eutil:getLanguage($edition as xs:string?) as xs:string {
      else(
          eutil:getPreference('application_language', $edition)
      )
-     
 };

--- a/add/data/xqm/util.xqm
+++ b/add/data/xqm/util.xqm
@@ -45,7 +45,7 @@ import module namespace functx = "http://www.functx.com" at "../xqm/functx-1.0-n
 : @return The string
 :)
 
-declare function eutil:getLocalizedName($node, $lang) {
+declare function eutil:getLocalizedName($node, $lang) as xs:string {
   let $nodeName := local-name($node)
   return
     if ($node/mei:title)
@@ -66,7 +66,7 @@ declare function eutil:getLocalizedName($node, $lang) {
             then $node/edirom:names/edirom:name[@xml:lang = $lang]/node()
             else $node/edirom:names/edirom:name[1]/node()
     )
-    else ($node)
+    else (normalize-space($node))
 };
 
 

--- a/add/data/xqm/util.xqm
+++ b/add/data/xqm/util.xqm
@@ -163,7 +163,6 @@ declare function eutil:getLanguageString($key as xs:string, $values as xs:string
         
 };
 
-
 (:~
 : Return a value of preference to key 
 :

--- a/add/data/xqm/util.xqm
+++ b/add/data/xqm/util.xqm
@@ -178,10 +178,6 @@ declare function eutil:getPreference($key as xs:string, $edition as xs:string?) 
      return    
         if($projectFile != 'null' and $projectFile//entry[@key = $key]) then ($projectFile//entry[@key = $key]/string(@value))
         else ($file//entry[@key = $key]/string(@value))
-         
-(:from freidi:)
-     (:if($projectFile) then ($projectFile//entry[@key = $key]/string(@value))
-     else ($file//entry[@key = $key]/string(@value)):)
      
 };
 

--- a/add/data/xqm/util.xqm
+++ b/add/data/xqm/util.xqm
@@ -24,19 +24,20 @@ xquery version "3.0";
 : This module provides library utility functions
 :
 : @author <a href="mailto:roewenstrunk@edirom.de">Daniel Röwenstrunk</a>
+: @author <a href="mailto:roewenstrunk@edirom.de">Nikolaos Beer</a>
+: @author <a href="mailto:bohl@edirom.de">Benjamin W. Bohl</a>
 :)
+
 module namespace eutil = "http://www.edirom.de/xquery/util";
 
 import module namespace work="http://www.edirom.de/xquery/work" at "work.xqm";
 import module namespace source="http://www.edirom.de/xquery/source" at "source.xqm";
 import module namespace teitext="http://www.edirom.de/xquery/teitext" at "teitext.xqm";
-
 import module namespace edition="http://www.edirom.de/xquery/edition" at "../xqm/edition.xqm";
+import module namespace functx = "http://www.functx.com" at "../xqm/functx-1.0-nodoc-2007-01.xq";
 
 declare namespace mei="http://www.music-encoding.org/ns/mei";
 declare namespace edirom="http://www.edirom.de/ns/1.3";
-
-import module namespace functx = "http://www.functx.com" at "../xqm/functx-1.0-nodoc-2007-01.xq";
 
 (:~
 : Returns a localized string
@@ -68,7 +69,6 @@ declare function eutil:getLocalizedName($node, $lang) as xs:string {
     )
     else (normalize-space($node))
 };
-
 
 (:~
 : Returns a document
@@ -160,7 +160,6 @@ declare function eutil:getLanguageString($key as xs:string, $values as xs:string
                         
     return
         $string
-        
 };
 
 (:~
@@ -172,7 +171,6 @@ declare function eutil:getLanguageString($key as xs:string, $values as xs:string
 declare function eutil:getPreference($key as xs:string, $edition as xs:string?) as xs:string {
 
      let $file := doc('../prefs/edirom-prefs.xml')
-        
      let $projectFile := doc(edition:getPreferencesURI($edition))
      
      return    


### PR DESCRIPTION
actually this PR reworks util.xqm

* the reason for getConcordance to fail was in util:getLocalizedName returning non-normalised $node if no explicit rule was defined for a node. This breaks the returned concordance-JSON due to the contained line-breaks
* adding fn:normalize-space fixed it

Moreover this PR does some Linton of the eutil module