### PR TITLE
Fix broken navigator

### DIFF
--- a/add/data/xqm/util.xqm
+++ b/add/data/xqm/util.xqm
@@ -1,4 +1,4 @@
-xquery version "3.0";
+xquery version "3.1";
 (:
   Edirom Online
   Copyright (C) 2011 The Edirom Project

--- a/add/data/xqm/util.xqm
+++ b/add/data/xqm/util.xqm
@@ -48,6 +48,7 @@ declare namespace edirom="http://www.edirom.de/ns/1.3";
 
 declare function eutil:getLocalizedName($node, $lang) as xs:string {
 
+let $name :=
     if ($node/mei:title)
     then (
         if ($lang = $node/mei:title/@xml:lang)
@@ -67,6 +68,8 @@ declare function eutil:getLocalizedName($node, $lang) as xs:string {
             else $node/edirom:names/edirom:name[1]/node()
     )
     else (normalize-space($node))
+return
+    $name => string-join(' ')
 };
 
 (:~


### PR DESCRIPTION
If there are more (text) values of titles than one (occurs in MEI 4.0.1), then ne Navigator brakes. To avoid that the incoming values are joined.