### PR TITLE
fix filter for measures on page

### DIFF
--- a/add/data/xql/getMeasuresOnPage.xql
+++ b/add/data/xql/getMeasuresOnPage.xql
@@ -45,7 +45,7 @@ declare option exist:serialize "method=text media-type=text/plain omit-xml-decla
 declare function local:getMeasures($mei as node(), $surface as node()) as xs:string* {
 
     for $zone in $surface/mei:zone[@type='measure']
-    let $measures := $mei//mei:measure[@facs = concat('#', $zone/@xml:id)]
+    let $measures := $mei//mei:measure[functx:contains-any-of(@facs, concat('#', $zone/@xml:id))]
     return
         for $measure in $measures
         let $measureLabel := if ($measure/@label) then ($measure/string(@label)) else ($measure/string(@n))

--- a/add/data/xql/getMeasuresOnPage.xql
+++ b/add/data/xql/getMeasuresOnPage.xql
@@ -31,6 +31,7 @@ declare namespace mei="http://www.music-encoding.org/ns/mei";
 declare namespace xlink="http://www.w3.org/1999/xlink";
 
 declare namespace xmldb="http://exist-db.org/xquery/xmldb";
+import module namespace functx = "http://www.functx.com" at "../xqm/functx-1.0-nodoc-2007-01.xq";
 
 declare option exist:serialize "method=text media-type=text/plain omit-xml-declaration=yes";
 

--- a/add/data/xql/getMeasuresOnPage.xql
+++ b/add/data/xql/getMeasuresOnPage.xql
@@ -45,7 +45,7 @@ declare option exist:serialize "method=text media-type=text/plain omit-xml-decla
 declare function local:getMeasures($mei as node(), $surface as node()) as xs:string* {
 
     for $zone in $surface/mei:zone[@type='measure']
-    let $measures := $mei//mei:measure[functx:contains-any-of(@facs, concat('#', $zone/@xml:id))]
+    let $measures := $mei//mei:measure[concat('#', $zone/@xml:id) = tokenize(@facs, ' ')]
     return
         for $measure in $measures
         let $measureLabel := if ($measure/@label) then ($measure/string(@label)) else ($measure/string(@n))

--- a/add/data/xql/getMeasuresOnPage.xql
+++ b/add/data/xql/getMeasuresOnPage.xql
@@ -44,7 +44,7 @@ declare option exist:serialize "method=text media-type=text/plain omit-xml-decla
 declare function local:getMeasures($mei as node(), $surface as node()) as xs:string* {
 
     for $zone in $surface/mei:zone[@type='measure']
-    let $measures := $mei//mei:measure[contains(@facs, concat('#', $zone/@xml:id))]
+    let $measures := $mei//mei:measure[@facs = concat('#', $zone/@xml:id)]
     return
         for $measure in $measures
         let $measureLabel := if ($measure/@label) then ($measure/string(@label)) else ($measure/string(@n))

--- a/add/data/xql/getMeasuresOnPage.xql
+++ b/add/data/xql/getMeasuresOnPage.xql
@@ -31,7 +31,6 @@ declare namespace mei="http://www.music-encoding.org/ns/mei";
 declare namespace xlink="http://www.w3.org/1999/xlink";
 
 declare namespace xmldb="http://exist-db.org/xquery/xmldb";
-import module namespace functx = "http://www.functx.com" at "../xqm/functx-1.0-nodoc-2007-01.xq";
 
 declare option exist:serialize "method=text media-type=text/plain omit-xml-declaration=yes";
 


### PR DESCRIPTION
Before contains() was used but this produces too many matches if the IDs contains floating numbers (multiple matches). Now the exact id must occur for a match.