### PR TITLE
Fix window title unknown

### DIFF
--- a/add/data/xql/getAnnotation.xql
+++ b/add/data/xql/getAnnotation.xql
@@ -409,11 +409,11 @@ return
                     then(
                         for $a in $annot/mei:annot
                         return
-                            (<h1>{annotation:getLocalizedTitle($annot)}</h1>, (:TODO vs eutil:getLocalizedName($annot, $lang) :)
+                            (<h1>{eutil:getLocalizedTitle($annot, $lang)}</h1>,
                             annotation:getContent($a,'', $edition))
                     )
                     else(
-                        (<h1>{annotation:getLocalizedTitle($annot)}</h1>,
+                        (<h1>{eutil:getLocalizedTitle($annot, $lang)}</h1>,
                         annotation:getContent($annot,'', $edition))
                     )
                 }

--- a/add/data/xql/getLinkTarget.xql
+++ b/add/data/xql/getLinkTarget.xql
@@ -1,4 +1,4 @@
-xquery version "3.0";
+xquery version "3.1";
 (:
   Edirom Online
   Copyright (C) 2011 The Edirom Project

--- a/add/data/xql/getLinkTarget.xql
+++ b/add/data/xql/getLinkTarget.xql
@@ -37,22 +37,6 @@ import module namespace functx = "http://www.functx.com" at "../xqm/functx-1.0-n
 
 declare variable $lang := request:get-parameter('lang', '');
 
-declare function local:getLocalizedMEITitle($node) {
-  let $nodeName := local-name($node)
-  return
-      if ($lang = $node/mei:title/@xml:lang)
-      then ($node/mei:title[@xml:lang = $lang]/text())
-      else ($node/mei:title[1]/text())
-};
-declare function local:getLocalizedTEITitle($node) {
-  let $nodeName := local-name($node)
-  return
-      if ($lang = $node/tei:title/@xml:lang)
-      then $node/tei:title[@xml:lang = $lang]/text()
-      else $node/tei:title[1]/text()
-
-};
-
 
 declare function local:getViews($type, $docUri, $doc) {
     

--- a/add/data/xql/search.xql
+++ b/add/data/xql/search.xql
@@ -19,6 +19,7 @@ xquery version "3.0";
 :)
 
 import module namespace kwic="http://exist-db.org/xquery/kwic";
+import module namespace eutil="http://www.edirom.de/xquery/util" at "../xqm/util.xqm";
 
 declare namespace tei="http://www.tei-c.org/ns/1.0";
 declare namespace mei="http://www.music-encoding.org/ns/mei";
@@ -27,24 +28,6 @@ declare namespace request="http://exist-db.org/xquery/request";
 (:declare option exist:serialize "method=xhtml media-type=text/html omit-xml-declaration=yes indent=yes";:)
 
 declare variable $lang := request:get-parameter('lang', '');
-
-declare function local:getLocalizedMEITitle($node) {
-  let $nodeName := local-name($node)
-  return
-      if ($lang = $node/mei:title/@xml:lang)
-      then $node/mei:title[@xml:lang = $lang]/text()
-      else $node/mei:title[1]/text()
-
-};
-
-declare function local:getLocalizedTEITitle($node) {
-  let $nodeName := local-name($node)
-  return
-      if ($lang = $node/tei:title/@xml:lang)
-      then $node/tei:title[@xml:lang = $lang]/text()
-      else $node/tei:title[1]/text()
-
-};
 
 declare function local:filter($node as node(), $mode as xs:string) as xs:string? {
   if ($mode eq 'before') then 
@@ -116,16 +99,16 @@ let $return :=
     let $uri := document-uri($doc)
     let $title := (: Annotation :)
               if(local-name($hit) eq 'annot')
-              then(local:getLocalizedMEITitle($hit))
+              then(eutil:getLocalizedTitle($hit, $lang))
               (: Work :)
               else if(exists($doc//mei:mei) and exists($doc//mei:work))
-              then(local:getLocalizedMEITitle($doc//mei:work/mei:titleStmt))
+              then(eutil:getLocalizedTitle($doc//mei:work/mei:titleStmt, $lang))
               (: Source / Score :)
               else if(exists($doc//mei:mei) and exists($doc//mei:source))
-              then(local:getLocalizedMEITitle($doc//mei:source/mei:titleStmt))
+              then(eutil:getLocalizedTitle($doc//mei:source/mei:titleStmt, $lang))
               (: Text :)
               else if(exists($doc/tei:TEI))
-              then(local:getLocalizedTEITitle($doc//tei:titleStmt))
+              then(eutil:getLocalizedTitle($doc//tei:titleStmt, $lang))
               else(string('unknown'))
     order by ft:score($hit) descending
     return

--- a/add/data/xqm/annotation.xqm
+++ b/add/data/xqm/annotation.xqm
@@ -37,16 +37,6 @@ declare namespace mei="http://www.music-encoding.org/ns/mei";
 declare namespace system="http://exist-db.org/xquery/system";
 declare namespace transform="http://exist-db.org/xquery/transform";
 
-declare function local:getLocalizedTitle($node) {
-  let $lang := request:get-parameter('lang', '')
-  let $nodeName := local-name($node)
-  return
-      if ($lang = $node/mei:title/@xml:lang)
-      then $node/mei:title[@xml:lang = $lang]/text()
-      else $node/mei:title[1]/text()
-
-};
-
 declare function local:getLocalizedName($node) {
   let $lang := request:get-parameter('lang', '')
   let $nodeName := local-name($node)
@@ -82,7 +72,8 @@ declare function annotation:annotationsToJSON($uri as xs:string, $edition as xs:
 :)
 declare function annotation:toJSON($anno as element(), $edition as xs:string) as xs:string {
     let $id := $anno/@xml:id
-    let $title := normalize-space(local:getLocalizedTitle($anno))
+    let $lang := request:get-parameter('lang', '')
+    let $title := eutil:getLocalizedTitle($anno, $lang)
     let $doc := $anno/root()
     let $prio := local:getLocalizedName($doc/id(substring($anno/mei:ptr[@type = 'priority']/@target,2)))
     let $pList := distinct-values(tokenize($anno/@plist, ' '))

--- a/add/data/xqm/util.xqm
+++ b/add/data/xqm/util.xqm
@@ -89,6 +89,34 @@ return
 };
 
 (:~
+: Returns a localized string
+:
+: @param $node The node to be processed
+: @param $lang Optional parameter for lang selection
+: @return The string (normalized space)
+:)
+
+declare function eutil:getLocalizedTitle($node as node(), $lang as xs:string?) as xs:string {
+
+  let $namespace := eutil:getNamespace($node)
+  
+  let $titleMEI := if ($lang != '' and $lang = $node/mei:title/@xml:lang)
+                   then ($node/mei:title[@xml:lang = $lang]//text() => string-join() => normalize-space())
+                   else (($node//mei:title)[1]//text() => string-join() => normalize-space())
+  
+  let $titleTEI := if ($lang != '' and $lang = $node/tei:title/@xml:lang)
+                   then $node/tei:title[@xml:lang = $lang]/text()
+                   else $node/tei:title[1]/text()
+  
+  return
+      if ($namespace = 'mei')
+      then($titleMEI)
+      else if ($namespace = 'tei')
+      then($titleTEI)
+      else('unknown')
+
+};
+(:~
 : Returns a document
 :
 : @param $uri The URIs of the documents to process

--- a/add/data/xqm/util.xqm
+++ b/add/data/xqm/util.xqm
@@ -37,6 +37,7 @@ import module namespace edition="http://www.edirom.de/xquery/edition" at "../xqm
 import module namespace functx = "http://www.functx.com" at "../xqm/functx-1.0-nodoc-2007-01.xq";
 
 declare namespace mei="http://www.music-encoding.org/ns/mei";
+declare namespace tei="http://www.tei-c.org/ns/1.0";
 declare namespace edirom="http://www.edirom.de/ns/1.3";
 
 (:~

--- a/add/data/xqm/util.xqm
+++ b/add/data/xqm/util.xqm
@@ -41,6 +41,21 @@ declare namespace tei="http://www.tei-c.org/ns/1.0";
 declare namespace edirom="http://www.edirom.de/ns/1.3";
 
 (:~
+: Returns the namespace (standardized prefix)
+:
+: @param $node The node to be processed
+: @return The namespace (prefix)
+:)
+
+declare function eutil:getNamespace($node as node()) as xs:string {
+  switch (namespace-uri($node))
+    case 'http://www.music-encoding.org/ns/mei' return 'mei'
+    case 'http://www.tei-c.org/ns/1.0' return 'tei'
+    case 'http://www.edirom.de/ns/1.3' return 'edirom'
+    default return 'unknown'
+};
+
+(:~
 : Returns a localized string
 :
 : @param $node The node to be processed

--- a/add/data/xqm/work.xqm
+++ b/add/data/xqm/work.xqm
@@ -33,15 +33,6 @@ import module namespace eutil="http://www.edirom.de/xquery/util" at "../xqm/util
 declare namespace mei="http://www.music-encoding.org/ns/mei";
 declare namespace edirom="http://www.edirom.de/ns/1.3";
 
-declare function local:getLocalizedTitle($node) {
-
-    let $lang := request:get-parameter('lang', '')     
-    return
-      if ($lang = $node/mei:title/@xml:lang)
-      then (normalize-space(($node/mei:title)[@xml:lang = $lang][1]/text()))
-      else (normalize-space(($node//mei:title)[1]/text()))
-};
-
 (:~
 : Returns a JSON representation of a Work
 :
@@ -51,12 +42,13 @@ declare function local:getLocalizedTitle($node) {
 declare function work:toJSON($uri as xs:string, $edition as xs:string) as xs:string {
     
     let $work := doc($uri)/mei:mei
+    let $lang := request:get-parameter('lang', '')
     return
         concat('
             {',
                 'id: "', $work/string(@xml:id), '", ',
                 'doc: "', $uri, '", ',
-                'title: "', replace(local:getLocalizedTitle($work//mei:work), '"', '\\"'), '"',
+                'title: "', replace(eutil:getLocalizedTitle($work//mei:work, $lang), '"', '\\"'), '"',
             '}')
 };
 
@@ -74,12 +66,13 @@ declare function work:isWork($uri as xs:string) as xs:boolean {
 (:~
 : Returns a works's label
 :
-: @param $source The URIs of the Work's document to process
+: @param $work The URIs of the Work's document to process
+: @param $edition The ID of the Edition the Work is part of
 : @return The label
 :)
 declare function work:getLabel($work as xs:string, $edition as xs:string) as xs:string {
      
-    local:getLocalizedTitle(doc($work)//mei:work)
+    eutil:getLocalizedTitle(doc($work)//mei:work, request:get-parameter('lang', ''))
 };
 
 (:~


### PR DESCRIPTION
The (source) window title was broken. Even if 'unknown' was shown the map entry was empty. The only way to resolve this was to create a function for the getting the title (update to getTargetUrl.xql). While doing this an noticing that this will also impact other places that work with local:getLocalized... I introduced a gerneralized function to util.xqm that detects the namespace and returns the title. Works for several MEI-Versions. I also updated other modules using this function so we can manage this centerallized.

Tested. Could be merged before the release.