### PR TITLE
Proxy for accessing ressources in the database

### DIFF
--- a/add/data/xql/proxy.xql
+++ b/add/data/xql/proxy.xql
@@ -1,0 +1,43 @@
+xquery version "3.0";
+(:
+  Edirom Online
+  Copyright (C) 2022 The Edirom Project
+  http://www.edirom.de
+
+  Edirom Online is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  Edirom Online is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Edirom Online.  If not, see <http://www.gnu.org/licenses/>.
+:)
+
+declare namespace request="http://exist-db.org/xquery/request";
+declare namespace response="http://exist-db.org/xquery/response";
+declare namespace util="http://exist-db.org/xquery/util";
+
+let $ressourcePath := request:get-parameter('ressourcePath', '')
+let $contentType := request:get-parameter('contentType', 'text/plain; charset=UTF-8')
+
+return
+    if(util:is-binary-doc('xmldb:exist://' || $ressourcePath))
+    then(
+        if(matches($contentType, 'text'))
+        then(
+            response:set-header('Content-Type', $contentType),
+            util:binary-to-string(util:binary-doc('xmldb:exist://' || $ressourcePath))
+            )
+        else(
+            response:stream-binary(util:binary-doc('xmldb:exist://' || $ressourcePath), $contentType)
+            )
+    )
+    else(
+        response:set-header('Content-Type', $contentType),
+        doc('xmldb:exist://' || $ressourcePath)
+    )


### PR DESCRIPTION
The proxy can be used to get access to documents and files in the database. The parameter `ressourcePath` is used to point to the file (e.g. `/db/apps/doc/resources/images/existdb-web.svg`). The parameter `contentType` is used to give the content type for the HTTP response (e.g. `application/xml`, `image/png`, `text/css;%20charset=UTF-8`, see https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types).