### PR TITLE
Fix relative graphic refs

### DIFF
--- a/add/data/xql/getText.xql
+++ b/add/data/xql/getText.xql
@@ -35,6 +35,7 @@ let $term := request:get-parameter('term', '')
 let $path := request:get-parameter('path', '')
 let $page := request:get-parameter('page', '')
 let $doc := eutil:getDoc($uri)/root()
+let $contextPath := request:get-context-path()
 
 let $xslInstruction := $doc//processing-instruction(xml-stylesheet)
 let $xslInstruction := for $i in fn:serialize($xslInstruction, ())
@@ -70,6 +71,7 @@ let $params := (
                 (: parameters for Edirom-Online :)
                 <param name="lang" value="{eutil:getLanguage($edition)}"/>,
                 <param name="docUri" value="{$uri}"/>,
+                <param name="contextPath" value="{$contextPath}"/>,
                 (: parameters for the TEI Stypesheets :)
                 <param name="autoHead" value="'false'"/>,
                 <param name="autoToc" value="'false'"/>,

--- a/add/data/xslt/teiBody2HTML.xsl
+++ b/add/data/xslt/teiBody2HTML.xsl
@@ -1,8 +1,9 @@
 <xsl:stylesheet xmlns="http://www.w3.org/1999/xhtml"
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:tei="http://www.tei-c.org/ns/1.0"
     xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:xs="http://www.w3.org/2001/XMLSchema"
-    xmlns:exist="http://exist.sourceforge.net/NS/exist"
+    xmlns:exist="http://exist.sourceforge.net/NS/exist" xmlns:functx="http://www.functx.com"
     exclude-result-prefixes="#default xs tei xhtml" version="2.0">
+    <xsl:include href="functx-1.0-nodoc-2007-01.xsl"/>
     <xsl:import href="tei/common2/tei-param.xsl"/>
     <xsl:import href="tei/common2/tei.xsl"/>
     <xsl:import href="tei/xhtml2/tei-param.xsl"/>
@@ -193,6 +194,12 @@
                 </xsl:when>
                 <xsl:when test="starts-with(@url, '/exist/')">
                     <xsl:value-of select="@url"/>
+                </xsl:when>
+                <xsl:when test="starts-with(@url, '../')">
+                    <xsl:variable name="folder-ups" select="functx:number-of-matches(@url, '../')"/>
+                    <xsl:variable name="uri-tokens" select="tokenize($docUri, '/')" as="xs:string*"/> 
+                    <!--<xsl:value-of select="string-join(($uri-tokens[position() lt last() - $folder-ups]), '/') || functx:substring-after-last-match(@url, '../')"/>-->
+                    <xsl:value-of select="substring-before($docUri, $uri-tokens[last()]) || functx:substring-after-last-match(@url, '../')"/>
                 </xsl:when>
                 <xsl:when test="@url != ''">
                     <xsl:value-of select="@url"/>

--- a/add/data/xslt/teiBody2HTML.xsl
+++ b/add/data/xslt/teiBody2HTML.xsl
@@ -33,6 +33,7 @@
     <xsl:param name="lang">en</xsl:param>
     <xsl:param name="base" as="xs:string"/>
     <xsl:param name="docUri" as="xs:anyURI"/>
+    <xsl:param name="contextPath" as="xs:string"/>
     <!-- OVERWRITE FOLLOWING TEI-PARAMS -->
     <!-- END OVERWRITE TEI-PARAMS -->
     <!-- FREIDI PARAMETER -->
@@ -197,9 +198,10 @@
                 </xsl:when>
                 <xsl:when test="starts-with(@url, '../')">
                     <xsl:variable name="folder-ups" select="functx:number-of-matches(@url, '../')"/>
-                    <xsl:variable name="uri-tokens" select="tokenize($docUri, '/')" as="xs:string*"/> 
-                    <!--<xsl:value-of select="string-join(($uri-tokens[position() lt last() - $folder-ups]), '/') || functx:substring-after-last-match(@url, '../')"/>-->
-                    <xsl:value-of select="substring-before($docUri, $uri-tokens[last()]) || functx:substring-after-last-match(@url, '../')"/>
+                    <xsl:variable name="unprefixedDocUri" select="substring-after($docUri, 'xmldb:exist:///db/')"/>
+                    <xsl:variable name="uri-tokens" select="tokenize($unprefixedDocUri, '/')" as="xs:string*"/> 
+<!--                    <xsl:value-of select="string-join(($uri-tokens[position() lt last() - $folder-ups]), '/') || functx:substring-after-last-match(@url, '../')"/>-->
+                    <xsl:value-of select="string-join(($contextPath, $uri-tokens[position() lt last() - $folder-ups + 1], functx:substring-after-last-match(@url, '\.\./')), '/')"/>
                 </xsl:when>
                 <xsl:when test="@url != ''">
                     <xsl:value-of select="@url"/>


### PR DESCRIPTION
When a tei:text encodes tei:graphics with relative `@url`the images were not displayed in Edirom-Online.  This modification correctly resolves to the corresponding directory.