### PR TITLE
Start documents as uris in prefs file

### DIFF
--- a/add/data/prefs/edirom-prefs.xml
+++ b/add/data/prefs/edirom-prefs.xml
@@ -29,5 +29,6 @@
         <entry key="image_server" value="leaflet"/>-->
         <entry key="image_server" value="digilib"/>
         <entry key="edition_path" value="/db/apps/contents"/>
+        <entry key="start_documents_uri" value=""/>
     </entries>
 </prefs>

--- a/app/Application.js
+++ b/app/Application.js
@@ -126,6 +126,8 @@ Ext.define('EdiromOnline.Application', {
                 urlParams.uri = urlParams.uri + window.location.hash; 
         
             app.on('ready', Ext.bind(window.loadLink, me, [urlParams.uri, {sort:'sortGrid'}], false), me, {single: true});
+        }else {
+            app.on('ready', Ext.bind(me.openStartDocuments, me), me, {single: true});
         }
     },
     
@@ -176,5 +178,11 @@ Ext.define('EdiromOnline.Application', {
 	
 	getURLParameter: function(parameter) {
         return decodeURIComponent((new RegExp('[?|&]' + parameter + '=' + '([^&;]+?)(&|#|;|$)').exec(location.search) || [null, ''])[1].replace(/\+/g, '%20')) || null;
+    },
+    
+    openStartDocuments: function() {
+        var me = this;
+        var uris = me.getController('PreferenceController').getPreference('start_documents_uri');
+        window.loadLink(uris);
     }
 });


### PR DESCRIPTION
You can now put a set of uris in the prefs file with the key `start_documents_uri`. These uris will be opened when Edirom starts. If you have uris as parameters in the url, the preference will be ignored.