### PR TITLE
rewrite queries to improve performance and output proper JSON

### DIFF
--- a/add/data/xql/getAnnotationsOnPage.xql
+++ b/add/data/xql/getAnnotationsOnPage.xql
@@ -64,7 +64,7 @@ declare function local:getAnnotations($sourceUriSharp as xs:string, $surfaceId a
         return 
             if(starts-with($p, $sourceUriSharp)) 
             then(substring-after($p, $sourceUriSharp)) 
-            else if($p.noSharp = $elems/(@xml:id,@id))
+            else if($elems/@xml:id[. = $p.noSharp] or $elems/@id[. = $p.noSharp])
             then($p.noSharp)
             else()
     let $svgList := local:getAnnotSVGs($id, $plist.raw, $elems)

--- a/add/data/xql/getAnnotationsOnPage.xql
+++ b/add/data/xql/getAnnotationsOnPage.xql
@@ -179,7 +179,7 @@ let $zones := $surface//mei:zone
 let $measureLike := 
     for $id in $zones[@type = 'measure' or @type = 'staff']/string(@xml:id)
 	let $ref := concat('#', $id)
-	return $mei//*[contains(@facs, $ref)]
+	return $mei//*[$ref = tokenize(@facs,'\s')]
 	
 let $svgLike := $surface//svg:svg
 

--- a/add/data/xqm/annotation.xqm
+++ b/add/data/xqm/annotation.xqm
@@ -44,7 +44,7 @@ declare function annotation:getLocalizedLabel($node) {
   let $label :=
     if($nodeName = 'category') (: new style, i.e. //category/label :)
     then(
-        if ($lang = $node/mei:label/@xml:lang)
+        if ($node/mei:label[@xml:lang = $lang])
         then $node/mei:label[@xml:lang = $lang]/text()
         else $node/mei:label[1]/text()
     )

--- a/add/index/collection.xconf
+++ b/add/index/collection.xconf
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <collection xmlns="http://exist-db.org/collection-config/1.0">
-    <index xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mei="http://www.music-encoding.org/ns/mei">
+    <index xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xlink="http://www.w3.org/1999/xlink">
         <fulltext default="none" attributes="no"/>
         <lucene>
             <analyzer class="org.apache.lucene.analysis.standard.StandardAnalyzer"/>
@@ -12,7 +11,7 @@
             <text qname="@target"/>
             <text qname="@plist" analyzer="ws"/>
             <text qname="@label"/>
-        <text qname="tei:text"/>
+            <text qname="tei:text"/>
             <text qname="tei:title" boost="2.0"/>
             <text qname="mei:meiHead">
                 <ignore qname="mei:title"/>
@@ -26,5 +25,8 @@
         <create qname="@facs" type="xs:string"/>
         <create qname="@n" type="xs:string"/>
         <create qname="@num" type="xs:integer"/>
+        <create qname="@xml:lang" type="xs:string"/>
+        <create qname="@xml:id" type="xs:string"/>
+        <create qname="@id" type="xs:string"/>
     </index>
 </collection>


### PR DESCRIPTION
While debugging via monex I found out that the functions `local:findAnnotations` and `local:getMeasures` were some bottlenecks since they were not able to employ the indexes properly.  

The main improvement (hack?) of this PR is to do a two-step query. A first predicate (which gets evaluated first in eXist) uses a simple `contains()` to narrow down the result set and the second predicate then picks the proper results from the smaller result set. 

A second modification introduced here is to return proper JSON (i.e. the mime type "application/json") which seems to work fine :) 