### PR TITLE
fix return of eutil:getLocalizedName()

### DIFF
--- a/add/data/xqm/util.xqm
+++ b/add/data/xqm/util.xqm
@@ -66,7 +66,7 @@ declare function eutil:getNamespace($node as node()) as xs:string {
 : @return The string
 :)
 
-declare function eutil:getLocalizedName($node, $lang) as xs:string {
+declare function eutil:getLocalizedName($node, $lang) {
 
 let $name :=
     if ($node/mei:title)
@@ -91,7 +91,9 @@ let $name :=
         then(annotation:generateTitle($node))
     else (normalize-space($node))
 return
-    $name => string-join(' ')
+    if($node/edirom:names)
+    then($name)
+    else($name => string-join(' ') => normalize-space())
 };
 
 (:~


### PR DESCRIPTION
The return of `eutil:getLocalizedName()` converted all nodes into a string. I added a conditional so for navigatorItems (their names) also nodes are allowed as output, e.g., `Partitur P<sup>ED</sup>`.
In case of a returned string I added a space normalization.