### PR TITLE
Fix: multiple editions handling

### DIFF
--- a/add/data/xqm/edition.xqm
+++ b/add/data/xqm/edition.xqm
@@ -100,7 +100,7 @@ declare function edition:getPreferencesURI($uri as xs:string) as xs:string {
 : Only succeeds if the supplied id is the @xml:id of a edirom:edition element in '/db/apps'.
 : If $editionID is the empty string, returns the URI of the first edition found in '/db/apps'.
 :
-: @param $editionID The ID of the Edition's document to process
+: @param $editionID The '@xml:id' of the edirom:edition document to process
 : @return The URI of the Edition file
 :)
 declare function edition:findEdition($editionID as xs:string) as xs:string {

--- a/add/data/xqm/edition.xqm
+++ b/add/data/xqm/edition.xqm
@@ -96,7 +96,9 @@ declare function edition:getPreferencesURI($uri as xs:string) as xs:string {
 };
 
 (:~
-: Returns the URI of the called Edition. Fallback: first found Edition
+: Returns the URI of the edition specified by the submitted $editionID parameter.
+: Only succeeds if the supplied id is the @xml:id of a edirom:edition element in '/db/apps'.
+: If $editionID is the empty string, returns the URI of the first edition found in '/db/apps'.
 :
 : @param $editionID The ID of the Edition's document to process
 : @return The URI of the Edition file

--- a/add/data/xqm/edition.xqm
+++ b/add/data/xqm/edition.xqm
@@ -101,14 +101,14 @@ declare function edition:getPreferencesURI($uri as xs:string) as xs:string {
 : @param $uri The URI of the Edition's document to process
 : @return The URI
 :)
-declare function edition:findEdition($uri as xs:string) as xs:string {
-    if($uri eq '')
+declare function edition:findEdition($editionID as xs:string) as xs:string {
+    if($editionID eq '')
     then(
         let $edition := (collection('/db/apps')//edirom:edition)[1]
         return 'xmldb:exist://' || document-uri($edition/root())
     )
     else (
-        let $edition := collection('/db/apps')//edirom:edition[@xml:id eq $uri]
+        let $edition := collection('/db/apps')//edirom:edition/id($editionID)
         return 'xmldb:exist://' || document-uri($edition/root())
     )
 };

--- a/add/data/xqm/edition.xqm
+++ b/add/data/xqm/edition.xqm
@@ -96,10 +96,10 @@ declare function edition:getPreferencesURI($uri as xs:string) as xs:string {
 };
 
 (:~
-: Returns the URI of the first found Edition
+: Returns the URI of the called Edition. Fallback: first found Edition
 :
-: @param $uri The URI of the Edition's document to process
-: @return The URI
+: @param $editionID The ID of the Edition's document to process
+: @return The URI of the Edition file
 :)
 declare function edition:findEdition($editionID as xs:string) as xs:string {
     if($editionID eq '')


### PR DESCRIPTION
The overview was working, but the selected editions were not loading. This fix makes it possible to handle multiple Edirom editions in one Edirom-Online instance.