### PR TITLE
Feature: Improve handling of part labels

### DIFF
--- a/add/data/locale/edirom-lang-de.xml
+++ b/add/data/locale/edirom-lang-de.xml
@@ -176,5 +176,40 @@
         <entry key="Bar_n" value="Takt {0}"/>
         <!-- XSL-FO specific -->
         <entry key="contentsWord" value="Inhaltsverzeichnis"/>
+        
+        <!-- PERFORMANCE MEDIUM -->
+        <entry key="perfMedium.perfRes.voice" value="Singstimme"/>
+        <entry key="perfMedium.perfRes.voiceSpeaking" value="Sprechstimme"/>
+        <entry key="perfMedium.perfRes.voiceHigh" value="Hohe Stimme"/>
+        <entry key="perfMedium.perfRes.voiceMiddle" value="Mittlere Stimme"/>
+        <entry key="perfMedium.perfRes.voiceLow" value="Tiefe Stimme"/>
+        <entry key="perfMedium.perfRes.soprano" value="Sopran"/>
+        <entry key="perfMedium.perfRes.alto" value="Alt"/>
+        <entry key="perfMedium.perfRes.tenor" value="Tenor"/>
+        <entry key="perfMedium.perfRes.bass" value="Bass"/>
+        
+        <entry key="perfMedium.perfRes.violin" value="Violine"/>
+        <entry key="perfMedium.perfRes.viola" value="Viola"/>
+        <entry key="perfMedium.perfRes.violoncello" value="Violoncello"/>
+        <entry key="perfMedium.perfRes.doubleBass" value="Kontrabass"/>
+        <entry key="perfMedium.perfRes.bassInstrumental" value="Bass (instrumental)"/>
+        
+        <entry key="perfMedium.perfRes.flute" value="Flöte"/>
+        <entry key="perfMedium.perfRes.oboe" value="Oboe"/>
+        <entry key="perfMedium.perfRes.clarinet" value="Klarinette"/>
+        <entry key="perfMedium.perfRes.hornEnglish" value="Englischhorn"/>
+        <entry key="perfMedium.perfRes.bassoon" value="Fagott"/>
+        
+        <entry key="perfMedium.perfRes.hornFrench" value="Horn"/>
+        <entry key="perfMedium.perfRes.trumpet" value="Trompete"/>
+        <entry key="perfMedium.perfRes.trombone" value="Posaune"/>
+        <entry key="perfMedium.perfRes.tuba" value="Tuba"/>
+        
+        <entry key="perfMedium.perfRes.timpani" value="Pauken"/>
+        <entry key="perfMedium.perfRes.bells" value="Glocken"/>
+        
+        <entry key="perfMedium.perfRes.harp" value="Harfe"/>
+        <entry key="perfMedium.perfRes.piano" value="Klavier"/>
+        <entry key="perfMedium.perfRes.organ" value="Orgel"/>
     </entries>
 </langFile>

--- a/add/data/locale/edirom-lang-en.xml
+++ b/add/data/locale/edirom-lang-en.xml
@@ -176,5 +176,40 @@
         <entry key="Bar_n" value="Bar {0}"/>
         <!-- XSL-FO specific -->
         <entry key="contentsWord" value="Table of contents"/>
+        
+        <!-- PERFORMANCE MEDIUM -->
+        <entry key="perfMedium.perfRes.voice" value="Voice (singing)"/>
+        <entry key="perfMedium.perfRes.voiceSpeaking" value="Voice (speaking)"/>
+        <entry key="perfMedium.perfRes.voiceHigh" value="High Voice"/>
+        <entry key="perfMedium.perfRes.voiceMiddle" value="Middle Voice"/>
+        <entry key="perfMedium.perfRes.voiceLow" value="Low Voice"/>
+        <entry key="perfMedium.perfRes.soprano" value="Soprano"/>
+        <entry key="perfMedium.perfRes.alto" value="Alto"/>
+        <entry key="perfMedium.perfRes.tenor" value="Tenor"/>
+        <entry key="perfMedium.perfRes.bass" value="Bass"/>
+        
+        <entry key="perfMedium.perfRes.violin" value="Violin"/>
+        <entry key="perfMedium.perfRes.viola" value="Viola"/>
+        <entry key="perfMedium.perfRes.violoncello" value="Violoncello"/>
+        <entry key="perfMedium.perfRes.doubleBass" value="Double Bass"/>
+        <entry key="perfMedium.perfRes.bassInstrumental" value="Bass (instrumental)"/>
+        
+        <entry key="perfMedium.perfRes.flute" value="Flute"/>
+        <entry key="perfMedium.perfRes.oboe" value="Oboe"/>
+        <entry key="perfMedium.perfRes.clarinet" value="Clarinet"/>
+        <entry key="perfMedium.perfRes.hornEnglish" value="English Horn"/>
+        <entry key="perfMedium.perfRes.bassoon" value="Bassoon"/>
+        
+        <entry key="perfMedium.perfRes.hornFrench" value="French Horn"/>
+        <entry key="perfMedium.perfRes.trumpet" value="Trumpet"/>
+        <entry key="perfMedium.perfRes.trombone" value="Trombone"/>
+        <entry key="perfMedium.perfRes.tuba" value="Tuba"/>
+        
+        <entry key="perfMedium.perfRes.timpani" value="Timpani"/>
+        <entry key="perfMedium.perfRes.bells" value="Bells"/>
+        
+        <entry key="perfMedium.perfRes.harp" value="Harp"/>
+        <entry key="perfMedium.perfRes.piano" value="Piano"/>
+        <entry key="perfMedium.perfRes.organ" value="Organ"/>
     </entries>
 </langFile>

--- a/add/data/xql/getMeasures.xql
+++ b/add/data/xql/getMeasures.xql
@@ -60,31 +60,17 @@ declare function local:getMeasures($mei as node(), $mdivID as xs:string) as xs:s
             let $measures := if ($mdiv//mei:measure/@label)
                                 then ($mdiv//mei:measure[.//mei:multiRest][number(substring-before(@label, '–')) <= $measureNNumber][.//mei:multiRest/number(@num) gt ($measureNNumber - number(substring-before(@label, '–')))])
                                 else ($mdiv//mei:measure[.//mei:multiRest][number(@n) lt $measureNNumber][.//mei:multiRest/number(@num) gt ($measureNNumber - number(@n))])
-            let $measures := if ($mdiv//mei:measure/@label)
-                                then (
-                                    for $part in $mdiv//mei:part
-                                        for $measure in $part//mei:measure[@label = $measureN][1] | $measures[ancestor::mei:part = $part]
-                                            let $voiceRef := $part//mei:staffDef/@decls
-                                            let $voiceID := substring-after($voiceRef, '#')
-                                            return
-                                                concat('{id:"', $measure/@xml:id, '",
-                                                voice: "', $voiceRef,
-                                                '", partLabel: "', $mei/id($voiceID)/@label,
-                                                '"}')
-                                )
-                                else (
-                                    for $part in $mdiv//mei:part
-(:                                    let $partMeasures := $part//mei:measure:)
-                                        for $measure in $part//mei:measure[@n = $measureN][1] | $measures[ancestor::mei:part = $part]
-                                            let $voiceRef := $part//mei:staffDef/@decls
-                                            let $voiceID := substring-after($voiceRef, '#')
-                                            return
-                                                concat('{id:"',
-                                                $measure/@xml:id,
-                                                '", voice: "', $voiceRef,
-                                                '", partLabel: "', $mei/id($voiceID)/@label,
-                                                '"}')
-                                )
+            let $measures := for $part in $mdiv//mei:part
+                                let $partMeasures := if($part//mei:measure/@label)
+                                                     then($part//mei:measure[@label = $measureN][1])
+                                                     else($part//mei:measure[@n = $measureN][1])
+                                for $measure in $partMeasures | $measures[ancestor::mei:part = $part]
+                                    let $voiceRef := $part//mei:staffDef/@decls
+                                    return
+                                        concat('{id:"', $measure/@xml:id, '",
+                                        voice: "', $voiceRef,
+                                        '", partLabel: "', eutil:getPartLabel($measure, 'measure'),
+                                        '"}')
             return
                 concat('{',
                     'id: "measure_', $mdiv/@xml:id, '_', $measureN, '", ',

--- a/add/data/xql/getParts.xql
+++ b/add/data/xql/getParts.xql
@@ -23,7 +23,7 @@ declare namespace request="http://exist-db.org/xquery/request";
 declare namespace mei="http://www.music-encoding.org/ns/mei";
 declare namespace xmldb="http://exist-db.org/xquery/xmldb";
 
-import module namespace eutil="http://www.edirom.de/xquery/util" at "/db/apps/Edirom-Online/data/xqm/util.xqm";
+import module namespace eutil="http://www.edirom.de/xquery/util" at "../xqm/util.xqm";
 
 declare option exist:serialize "method=text media-type=text/plain omit-xml-declaration=yes";
 

--- a/add/data/xql/getParts.xql
+++ b/add/data/xql/getParts.xql
@@ -1,4 +1,4 @@
-xquery version "1.0";
+xquery version "3.1";
 (:
   Edirom Online
   Copyright (C) 2011 The Edirom Project
@@ -21,8 +21,9 @@ xquery version "1.0";
 
 declare namespace request="http://exist-db.org/xquery/request";
 declare namespace mei="http://www.music-encoding.org/ns/mei";
-
 declare namespace xmldb="http://exist-db.org/xquery/xmldb";
+
+import module namespace eutil="http://www.edirom.de/xquery/util" at "/db/apps/Edirom-Online/data/xqm/util.xqm";
 
 declare option exist:serialize "method=text media-type=text/plain omit-xml-declaration=yes";
 
@@ -30,6 +31,6 @@ let $uri := request:get-parameter('uri', '')
 let $mei := doc($uri)/root()
 
 let $ret := for $part in ($mei//mei:instrumentation/mei:instrVoice | $mei//mei:perfMedium//mei:perfRes)
-            return concat('{label: "', $part/@label, '", id:"', $part/@xml:id, '", selectedByDefault:true, selected:true}')
+            return concat('{label: "', eutil:getPartLabel($part, 'perfRes'), '", id:"', $part/@xml:id, '", selectedByDefault:true, selected:true}')
 
 return concat('[', string-join($ret, ','), ']')

--- a/add/data/xql/getParts.xql
+++ b/add/data/xql/getParts.xql
@@ -31,6 +31,13 @@ let $uri := request:get-parameter('uri', '')
 let $mei := doc($uri)/root()
 
 let $ret := for $part in ($mei//mei:instrumentation/mei:instrVoice | $mei//mei:perfMedium//mei:perfRes)
-            return concat('{label: "', eutil:getPartLabel($part, 'perfRes'), '", id:"', $part/@xml:id, '", selectedByDefault:true, selected:true}')
+                let $hasNoAttrSameas := not(exists($part/@sameas))
+                return
+                    concat(
+                            '{label: "', eutil:getPartLabel($part, 'perfRes'),
+                            '", id:"', $part/@xml:id,
+                            '", selectedByDefault:', $hasNoAttrSameas,
+                            ', selected:', $hasNoAttrSameas, '}'
+                          )
 
 return concat('[', string-join($ret, ','), ']')

--- a/add/data/xqm/source.xqm
+++ b/add/data/xqm/source.xqm
@@ -1,4 +1,4 @@
-xquery version "3.1";
+xquery version "1.0";
 (:
   Edirom Online
   Copyright (C) 2011 The Edirom Project
@@ -31,7 +31,7 @@ module namespace source = "http://www.edirom.de/xquery/source";
 
 declare namespace mei="http://www.music-encoding.org/ns/mei";
 
-import module namespace eutil="http://www.edirom.de/xquery/util" at "/db/apps/Edirom-Online/data/xqm/util.xqm";
+import module namespace eutil="http://www.edirom.de/xquery/util" at "../xqm/util.xqm";
 
 (:~
 : Returns whether a document is a source or not

--- a/add/data/xqm/source.xqm
+++ b/add/data/xqm/source.xqm
@@ -1,4 +1,4 @@
-xquery version "1.0";
+xquery version "3.1";
 (:
   Edirom Online
   Copyright (C) 2011 The Edirom Project
@@ -31,7 +31,7 @@ module namespace source = "http://www.edirom.de/xquery/source";
 
 declare namespace mei="http://www.music-encoding.org/ns/mei";
 
-import module namespace eutil="http://www.edirom.de/xquery/util" at "../xqm/util.xqm";
+import module namespace eutil="http://www.edirom.de/xquery/util" at "/db/apps/Edirom-Online/data/xqm/util.xqm";
 
 (:~
 : Returns whether a document is a source or not

--- a/add/data/xqm/util.xqm
+++ b/add/data/xqm/util.xqm
@@ -190,6 +190,37 @@ declare function eutil:getDocumentLabel($doc as xs:string, $edition as xs:string
 };
 
 (:~
+: Returns a part's label (translated if available)
+:
+: @author Dennis Ried
+: @param $partID The xml:id of the Part's node() to process
+: @return The label (translated if available)
+:)
+declare function eutil:getPartLabel($measureOrPerfRes as node(), $type as xs:string) as xs:string {
+            (: request:get-parameter('lang', '') doesn't work?? [DeRi]:)
+let $lang := if(request:get-parameter('lang', '') = '')
+             then('de')
+             else(request:get-parameter('lang', '')) 
+let $part := $measureOrPerfRes/ancestor::mei:part
+let $voiceRef := $part//mei:staffDef/@decls
+let $voiceID := substring-after($voiceRef, '#')
+
+let $perfResLabel := if($type eq 'measure')
+                     then($measureOrPerfRes/ancestor::mei:mei/id($voiceID)/@label)
+                     else($measureOrPerfRes/@label)
+let $dictKey := 'perfMedium.perfRes.' || functx:substring-before-if-contains($perfResLabel,'.')
+let $label := if(eutil:getLanguageString($dictKey, (), $lang))
+              then(eutil:getLanguageString($dictKey, (), $lang))
+              else($perfResLabel)
+let $numbering := for $i in subsequence(tokenize($perfResLabel,'\.'),2)
+                    where matches($i, '([0-9])|([ivxIVX])')
+                    return
+                        upper-case($i)
+return
+    normalize-space(string-join(($label, $numbering),' '))
+};
+
+(:~
 : Returns a language specific string
 :
 : @param $key The key to search for


### PR DESCRIPTION
- The part labels in the measureBasedView are accessed by a function.
- The label in the view and the label in the filter menu are identical now.
- The label is translated by the dictionary if the value is available (else the original value will be returned)
- if a list with a numbering is used, e.g., `violin.i` or `trumpet.2` the numbering will be treated as `Violin I` or `Trumpet 2`