### PR TITLE
Fix: prevent multiple values for sorting

### DIFF
--- a/add/data/xqm/util.xqm
+++ b/add/data/xqm/util.xqm
@@ -281,7 +281,7 @@ declare function eutil:get-app-base-url() as xs:string? {
  :)
 declare function eutil:sort-as-numeric-alpha($seq as item()* )  as item()* {
    for $item in $seq
-   let $itemPart1 := functx:get-matches($item, '\d+')
+   let $itemPart1 := (functx:get-matches($item, '\d+'))[1]
    let $itemPart2 := substring-after($item, $itemPart1)
    order by number($itemPart1), $itemPart2
    return $item


### PR DESCRIPTION
If a measure label contains a delimiter, e.g., `/ or -` the regex for sorting returns all numbers as a list. This fix forces to use the first number given.