### PR TITLE
Fix: annotationList and annotationPreview

### DIFF
--- a/add/data/xqm/annotation.xqm
+++ b/add/data/xqm/annotation.xqm
@@ -99,7 +99,9 @@ declare function annotation:toJSON($anno as element(), $edition as xs:string) as
             else(collection(eutil:getPreference('edition_path', $edition))//id($p)/root())
         return 
             if ($pDoc//mei:sourceDesc/mei:source/mei:identifier[@type = 'siglum'])
-            then $pDoc//mei:sourceDesc/mei:source/mei:identifier[@type = 'siglum']/text()
+            then ($pDoc//mei:sourceDesc/mei:source/mei:identifier[@type = 'siglum']/text())
+            else if ($pDoc//mei:manifestationList/mei:manifestation/mei:identifier[@type = 'siglum'])
+            then ($pDoc//mei:manifestationList/mei:manifestation/mei:identifier[@type = 'siglum']/text())
             else ($pDoc//mei:title[@type = 'siglum']/text())
     
     let $classes := tokenize(replace(normalize-space($anno/@class),'#',''),' ')

--- a/add/data/xqm/source.xqm
+++ b/add/data/xqm/source.xqm
@@ -41,9 +41,13 @@ import module namespace eutil="http://www.edirom.de/xquery/util" at "../xqm/util
 :)
 declare function source:isSource($uri as xs:string) as xs:boolean {
     let $doc := eutil:getDoc($uri)
+    let $meiVersionRegex := '(([4-9])|(\d+[0-9]))\.\d+\.\d+(-dev)?'
     return
-        exists($doc//mei:mei) and exists($doc//mei:source) (:mei2 and ?3 :)
-        or ($doc//mei:mei/@meiversion = ("4.0.0", "4.0.1") and exists($doc//mei:manifestation[@singleton='true'])) (:mei4 :)
+        (exists($doc//mei:mei) and exists($doc//mei:source)) (:mei2 and ?3 :)
+        or
+        (matches($doc//mei:mei/@meiversion, $meiVersionRegex) and exists($doc//mei:manifestation[@singleton='true'])) (:mei4+ for manuscripts:)
+        or
+        (matches($doc//mei:mei/@meiversion, $meiVersionRegex) and exists($doc//mei:manifestation//mei:item)) (: mei4+ for prints :)
 };
 
 (:~


### PR DESCRIPTION
The annotation list didn't show the source sigla because of an outdated xpath (MEI3 and earlier). This PR provides an update for MEI4 and MEI5-dev. Further the annotation preview was broken because of the `source:isSource()` function. It was just checking manuscripts or sources in MEI3 or older. Now it checks also prints and also later versions, e.g. MEI5-dev using a regex.

Note: Since a manuscript requires `<manifestation singleton="true"/>`, I added analogously that a print requires `<item>`.