### PR TITLE
Fix: adjust return values to function signatures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ Thumbs.db
 /tmp
 *.xpr
 local.properties
+.idea/

--- a/add/data/xqm/edition.xqm
+++ b/add/data/xqm/edition.xqm
@@ -69,7 +69,7 @@ declare function edition:getUris() as xs:string* {
 :)
 declare function edition:getWorkUris($uri as xs:string) as xs:string* {
     
-    doc($uri)//edirom:work/string(@xlink:href)
+    doc($uri)//edirom:work/@xlink:href ! string(.)
 };
 
 (:~
@@ -81,7 +81,7 @@ declare function edition:getWorkUris($uri as xs:string) as xs:string* {
 :)
 declare function edition:getLanguageFileURI($uri as xs:string, $lang as xs:string) as xs:string {
     
-    doc($uri)//edirom:language[@xml:lang eq $lang]/string(@xlink:href)
+    doc($uri)//edirom:language[@xml:lang eq $lang]/@xlink:href => string()
 };
 
 (:~
@@ -92,7 +92,7 @@ declare function edition:getLanguageFileURI($uri as xs:string, $lang as xs:strin
 :)
 declare function edition:getPreferencesURI($uri as xs:string) as xs:string {
     
-    doc($uri)//edirom:preferences/string(@xlink:href)
+    doc($uri)//edirom:preferences/@xlink:href => string()
 };
 
 (:~
@@ -122,7 +122,7 @@ declare function edition:findEdition($editionID as xs:string) as xs:string {
 : @return the text contents of edirom:edition/edirom:editionName
 :)
 declare function edition:getName($uri as xs:string) as xs:string {
-  doc($uri)/edirom:edition/edirom:editionName/text()
+  doc($uri)/edirom:edition/edirom:editionName => fn:normalize-space()
 };
 
 (:~


### PR DESCRIPTION
This is my try to fix #309. I basically replaced `/string(@attribute)` with `/@attribute => string()` to make sure the return type is `xs:string` even when the leading XPath expression returns the empty sequence.

NB, no error checking was introduced, so if e.g., (for any reason) there are multiple `edirom:language` with the same `@xml:lang`, the function `edition:getLanguageFileURI` will break. 