### PR TITLE
add fallback for missing user-prefs

### DIFF
--- a/add/data/xqm/edition.xqm
+++ b/add/data/xqm/edition.xqm
@@ -125,7 +125,9 @@ declare function edition:getLanguageCodesSorted($uri as xs:string) as xs:string 
  :)
 declare function edition:getPreferencesURI($uri as xs:string) as xs:string {
     
-    doc($uri)//edirom:preferences/@xlink:href => string()
+    if(doc($uri)//edirom:preferences/@xlink:href => string()) then(
+        doc($uri)//edirom:preferences/@xlink:href => string()
+    ) else ('../prefs/edirom-prefs.xml')
 };
 
 (:~


### PR DESCRIPTION
When no preferences are found an error occurs. The Edirom then should use the default preferences.