### PR TITLE
Fix for #281

### DIFF
--- a/add/data/xql/getAnnotation.xql
+++ b/add/data/xql/getAnnotation.xql
@@ -202,11 +202,11 @@ declare function local:getItemLabel($elem as element()) {
 
     let $name := local-name($elem)
     return (
-        if ($name = 'measure') then (
+        if($name = 'measure') then (
             if ($lang = 'de') then
-                (concat('Takt ', $elem/@n))
+                (concat('Takt ', if ($elem/@label) then ($elem/@label) else ($elem/@n)))
             else
-                (concat('Bar ', $elem/@n))
+                (concat('Bar ',if ($elem/@label) then ($elem/@label) else ($elem/@n)))
         ) else
             (),
 


### PR DESCRIPTION
Labels for measure numbers for measure previews in annot tool tips are now read from `@label` when present.