### PR TITLE
checkout repository recursively in Github action 

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - name: Chekout repository
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      with:
+        submodules: 'recursive'
       
     - name: Get short sha
       uses: benjlevesque/short-sha@599815c8ee942a9616c92bcfb4f947a3b670ab0b # v3.0


### PR DESCRIPTION
## Description, Context and related Issue

@obertsalome  and I were testing the current build artifact and realized that the TEI Stylesheets were missing in the EOL xar which caused the Edirom to fail miserably.  Introducing `submodules: 'recursive'` will hopefully fix this – or is there any reason to exclude the submodules from the build here?

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Refs #370

## How Has This Been Tested?
Not at all

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

