### PR TITLE
replace proprietary `exist:serialize` options

### DIFF
--- a/add/data/xql/edirom_printPreview.xql
+++ b/add/data/xql/edirom_printPreview.xql
@@ -16,9 +16,9 @@ declare namespace fo = "http://www.w3.org/1999/XSL/Format";
 declare namespace mei = "http://www.music-encoding.org/ns/mei";
 declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
 declare namespace request = "http://exist-db.org/xquery/request";
+declare namespace system = "http://exist-db.org/xquery/system";
 declare namespace tei = "http://www.tei-c.org/ns/1.0";
-declare namespace xhtml = "http://www.w3.org/1999/xhtml";
-declare namespace xslfo = "http://exist-db.org/xquery/xslfo";
+declare namespace transform = "http://exist-db.org/xquery/transform";
 
 (: OPTION DECLARATIONS ===================================================== :)
 

--- a/add/data/xql/edirom_printPreview.xql
+++ b/add/data/xql/edirom_printPreview.xql
@@ -14,6 +14,7 @@ import module namespace eutil = "http://www.edirom.de/xquery/util" at "../xqm/ut
 declare namespace eof = "http://www.edirom.de/xquery/ediromOnlineFunctions";
 declare namespace fo = "http://www.w3.org/1999/XSL/Format";
 declare namespace mei = "http://www.music-encoding.org/ns/mei";
+declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
 declare namespace request = "http://exist-db.org/xquery/request";
 declare namespace tei = "http://www.tei-c.org/ns/1.0";
 declare namespace xhtml = "http://www.w3.org/1999/xhtml";
@@ -21,7 +22,10 @@ declare namespace xslfo = "http://exist-db.org/xquery/xslfo";
 
 (: OPTION DECLARATIONS ===================================================== :)
 
-declare option exist:serialize "method=html media-type=text/html omit-xml-declaration=yes indent=yes";
+declare option output:media-type "text/html";
+declare option output:method "html";
+declare option output:indent "yes";
+declare option output:omit-xml-declaration "yes";
 
 (: VARIABLE DECLARATIONS =================================================== :)
 

--- a/add/data/xql/getAnnotationsInRendering.xql
+++ b/add/data/xql/getAnnotationsInRendering.xql
@@ -17,12 +17,14 @@ import module namespace eutil = "http://www.edirom.de/xquery/util" at "../xqm/ut
 (: NAMESPACE DECLARATIONS ================================================== :)
 
 declare namespace mei = "http://www.music-encoding.org/ns/mei";
+declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
 declare namespace xlink = "http://www.w3.org/1999/xlink";
 declare namespace request = "http://exist-db.org/xquery/request";
 
 (: OPTION DECLARATIONS ===================================================== :)
 
-declare option exist:serialize "method=text media-type=text/plain omit-xml-declaration=yes";
+declare option output:media-type "text/plain";
+declare option output:method "text";
 
 declare function local:getAnnotations($edition as xs:string, $edition_path as xs:string, $uri as xs:string, $elemIds as xs:string*) as xs:string* {
     

--- a/add/data/xql/getAnnotationsInText.xql
+++ b/add/data/xql/getAnnotationsInText.xql
@@ -13,13 +13,15 @@ xquery version "3.1";
 
 declare namespace ft = "http://exist-db.org/xquery/lucene";
 declare namespace mei = "http://www.music-encoding.org/ns/mei";
+declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
 declare namespace request = "http://exist-db.org/xquery/request";
 declare namespace xlink = "http://www.w3.org/1999/xlink";
 declare namespace xmldb = "http://exist-db.org/xquery/xmldb";
 
 (: OPTION DECLARATIONS ===================================================== :)
 
-declare option exist:serialize "method=text media-type=text/plain omit-xml-declaration=yes";
+declare option output:media-type "text/plain";
+declare option output:method "text";
 
 (:~
     Finds all annotations in all works.

--- a/add/data/xql/getAudioPlayer.xql
+++ b/add/data/xql/getAudioPlayer.xql
@@ -10,11 +10,15 @@ import module namespace eutil = "http://www.edirom.de/xquery/util" at "../xqm/ut
 (: NAMESPACE DECLARATIONS ================================================== :)
 
 declare namespace mei = "http://www.music-encoding.org/ns/mei";
+declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
 declare namespace request = "http://exist-db.org/xquery/request";
 
 (: OPTION DECLARATIONS ===================================================== :)
 
-declare option exist:serialize "method=xhtml media-type=text/html omit-xml-declaration=yes indent=yes";
+declare option output:media-type "text/html";
+declare option output:method "xhtml";
+declare option output:indent "yes";
+declare option output:omit-xml-declaration "yes";
 
 (: QUERY BODY ============================================================== :)
 

--- a/add/data/xql/getChapters.xql
+++ b/add/data/xql/getChapters.xql
@@ -9,6 +9,7 @@ import module namespace eutil = "http://www.edirom.de/xquery/util" at "../xqm/ut
 
 (: NAMESPACE DECLARATIONS ================================================== :)
 
+declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
 declare namespace request = "http://exist-db.org/xquery/request";
 declare namespace tei = "http://www.tei-c.org/ns/1.0";
 declare namespace xlink = "http://www.w3.org/1999/xlink";
@@ -16,7 +17,8 @@ declare namespace xmldb = "http://exist-db.org/xquery/xmldb";
 
 (: OPTION DECLARATIONS ===================================================== :)
 
-declare option exist:serialize "method=text media-type=text/plain omit-xml-declaration=yes";
+declare option output:media-type "text/plain";
+declare option output:method "text";
 
 (: FUNCTION DECLARATIONS =================================================== :)
 

--- a/add/data/xql/getConcordances.xql
+++ b/add/data/xql/getConcordances.xql
@@ -11,13 +11,15 @@ import module namespace eutil = "http://www.edirom.de/xquery/util" at "../xqm/ut
 
 declare namespace edirom = "http://www.edirom.de/ns/1.3";
 declare namespace mei = "http://www.music-encoding.org/ns/mei";
+declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
 declare namespace request = "http://exist-db.org/xquery/request";
 declare namespace xlink = "http://www.w3.org/1999/xlink";
 declare namespace xmldb = "http://exist-db.org/xquery/xmldb";
 
 (: OPTION DECLARATIONS ===================================================== :)
 
-declare option exist:serialize "method=text media-type=text/plain omit-xml-declaration=yes";
+declare option output:media-type "text/plain";
+declare option output:method "text";
 
 (: VARIABLE DECLARATIONS =================================================== :)
 

--- a/add/data/xql/getEdition.xql
+++ b/add/data/xql/getEdition.xql
@@ -13,9 +13,15 @@ xquery version "3.1";
 
 import module namespace edition = "http://www.edirom.de/xquery/edition" at "../xqm/edition.xqm";
 
+(: NAMESPACE DECLARATIONS ================================================== :)
+
+declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
+declare namespace request = "http://exist-db.org/xquery/request";
+
 (: OPTION DECLARATIONS ===================================================== :)
 
-declare option exist:serialize "method=text media-type=text/plain omit-xml-declaration=yes";
+declare option output:media-type "text/plain";
+declare option output:method "text";
 
 (: QUERY BODY ============================================================== :)
 

--- a/add/data/xql/getEditionURI.xql
+++ b/add/data/xql/getEditionURI.xql
@@ -13,9 +13,15 @@ xquery version "3.1";
 
 import module namespace edition = "http://www.edirom.de/xquery/edition" at "../xqm/edition.xqm";
 
+(: NAMESPACE DECLARATIONS ================================================== :)
+
+declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
+declare namespace request = "http://exist-db.org/xquery/request";
+
 (: OPTION DECLARATIONS ===================================================== :)
 
-declare option exist:serialize "method=text media-type=text/plain omit-xml-declaration=yes";
+declare option output:media-type "text/plain";
+declare option output:method "text";
 
 (: QUERY BODY ============================================================== :)
 

--- a/add/data/xql/getExtendedStaff.xql
+++ b/add/data/xql/getExtendedStaff.xql
@@ -11,6 +11,7 @@ import module namespace eutil = "http://www.edirom.de/xquery/util" at "../xqm/ut
 (: NAMESPACE DECLARATIONS ================================================== :)
 
 declare namespace mei = "http://www.music-encoding.org/ns/mei";
+declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
 declare namespace request = "http://exist-db.org/xquery/request";
 declare namespace system = "http://exist-db.org/xquery/system";
 declare namespace tei = "http://www.tei-c.org/ns/1.0";
@@ -19,7 +20,10 @@ declare namespace xmldb = "http://exist-db.org/xquery/xmldb";
 
 (: OPTION DECLARATIONS ===================================================== :)
 
-declare option exist:serialize "method=xhtml media-type=text/html omit-xml-declaration=yes indent=yes";
+declare option output:media-type "text/html";
+declare option output:method "xhtml";
+declare option output:indent "yes";
+declare option output:omit-xml-declaration "yes";
 
 (: QUERY BODY ============================================================== :)
 

--- a/add/data/xql/getHeader.xql
+++ b/add/data/xql/getHeader.xql
@@ -10,6 +10,7 @@ import module namespace eutil = "http://www.edirom.de/xquery/util" at "../xqm/ut
 (: NAMESPACE DECLARATIONS ================================================== :)
 
 declare namespace mei = "http://www.music-encoding.org/ns/mei";
+declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
 declare namespace request = "http://exist-db.org/xquery/request";
 declare namespace system = "http://exist-db.org/xquery/system";
 declare namespace tei = "http://www.tei-c.org/ns/1.0";
@@ -18,7 +19,10 @@ declare namespace xmldb = "http://exist-db.org/xquery/xmldb";
 
 (: OPTION DECLARATIONS ===================================================== :)
 
-declare option exist:serialize "method=xhtml media-type=text/html omit-xml-declaration=yes indent=yes";
+declare option output:media-type "text/html";
+declare option output:method "xhtml";
+declare option output:indent "yes";
+declare option output:omit-xml-declaration "yes";
 
 (: QUERY BODY ============================================================== :)
 

--- a/add/data/xql/getHelp.xql
+++ b/add/data/xql/getHelp.xql
@@ -3,9 +3,19 @@ xquery version "3.1";
  : For LICENSE-Details please refer to the LICENSE file in the root directory of this repository.
  :)
 
+(: NAMESPACE DECLARATIONS ================================================== :)
+
+declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
+declare namespace request = "http://exist-db.org/xquery/request";
+declare namespace system = "http://exist-db.org/xquery/system";
+declare namespace transform = "http://exist-db.org/xquery/transform";
+
 (: OPTION DECLARATIONS ===================================================== :)
 
-declare option exist:serialize "method=xhtml media-type=text/html omit-xml-declaration=yes indent=yes";
+declare option output:media-type "text/html";
+declare option output:method "xhtml";
+declare option output:indent "yes";
+declare option output:omit-xml-declaration "yes";
 
 (: QUERY BODY ============================================================== :)
 

--- a/add/data/xql/getInternalIdType.xql
+++ b/add/data/xql/getInternalIdType.xql
@@ -10,11 +10,13 @@ import module namespace functx = "http://www.functx.com";
 (: NAMESPACE DECLARATIONS ================================================== :)
 
 declare namespace mei = "http://www.music-encoding.org/ns/mei";
+declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
 declare namespace request = "http://exist-db.org/xquery/request";
 
 (: OPTION DECLARATIONS ===================================================== :)
 
-declare option exist:serialize "method=text media-type=text/plain omit-xml-declaration=yes";
+declare option output:media-type "text/plain";
+declare option output:method "text";
 
 (: QUERY BODY ============================================================== :)
 

--- a/add/data/xql/getLanguageFile.xql
+++ b/add/data/xql/getLanguageFile.xql
@@ -15,11 +15,15 @@ import module namespace edition = "http://www.edirom.de/xquery/edition" at "../x
 
 (: NAMESPACE DECLARATIONS ================================================== :)
 
+declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
 declare namespace request = "http://exist-db.org/xquery/request";
 
 (: OPTION DECLARATIONS ===================================================== :)
 
-declare option exist:serialize "method=xhtml media-type=text/html omit-xml-declaration=yes indent=yes";
+declare option output:media-type "text/html";
+declare option output:method "xhtml";
+declare option output:indent "yes";
+declare option output:omit-xml-declaration "yes";
 
 (: QUERY BODY ============================================================== :)
 

--- a/add/data/xql/getMeasurePage.xql
+++ b/add/data/xql/getMeasurePage.xql
@@ -6,13 +6,15 @@ xquery version "3.1";
 (: NAMESPACE DECLARATIONS ================================================== :)
 
 declare namespace mei = "http://www.music-encoding.org/ns/mei";
+declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
 declare namespace request = "http://exist-db.org/xquery/request";
 declare namespace xlink = "http://www.w3.org/1999/xlink";
 declare namespace xmldb = "http://exist-db.org/xquery/xmldb";
 
 (: OPTION DECLARATIONS ===================================================== :)
 
-declare option exist:serialize "method=text media-type=text/plain omit-xml-declaration=yes";
+declare option output:media-type "text/plain";
+declare option output:method "text";
 
 (: FUNCTION DECLARATIONS =================================================== :)
 

--- a/add/data/xql/getMeasures.xql
+++ b/add/data/xql/getMeasures.xql
@@ -12,13 +12,15 @@ import module namespace eutil = "http://www.edirom.de/xquery/util" at "/db/apps/
 (: NAMESPACE DECLARATIONS ================================================== :)
 
 declare namespace mei = "http://www.music-encoding.org/ns/mei";
+declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
 declare namespace request = "http://exist-db.org/xquery/request";
 declare namespace xlink = "http://www.w3.org/1999/xlink";
 declare namespace xmldb = "http://exist-db.org/xquery/xmldb";
 
 (: OPTION DECLARATIONS ===================================================== :)
 
-declare option exist:serialize "method=text media-type=text/plain omit-xml-declaration=yes";
+declare option output:media-type "text/plain";
+declare option output:method "text";
 
 (: FUNCTION DECLARATIONS =================================================== :)
 

--- a/add/data/xql/getMovementsFirstPage.xql
+++ b/add/data/xql/getMovementsFirstPage.xql
@@ -6,13 +6,13 @@ xquery version "3.1";
 (: NAMESPACE DECLARATIONS ================================================== :)
 
 declare namespace mei = "http://www.music-encoding.org/ns/mei";
+declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
 declare namespace request = "http://exist-db.org/xquery/request";
-declare namespace xlink = "http://www.w3.org/1999/xlink";
-declare namespace xmldb = "http://exist-db.org/xquery/xmldb";
 
 (: OPTION DECLARATIONS ===================================================== :)
 
-declare option exist:serialize "method=text media-type=text/plain omit-xml-declaration=yes";
+declare option output:media-type "text/plain";
+declare option output:method "text";
 
 (: QUERY BODY ============================================================== :)
 

--- a/add/data/xql/getNavigatorConfig.xql
+++ b/add/data/xql/getNavigatorConfig.xql
@@ -10,13 +10,17 @@ import module namespace eutil = "http://www.edirom.de/xquery/util" at "../xqm/ut
 (: NAMESPACE DECLARATIONS ================================================== :)
 
 declare namespace edirom = "http://www.edirom.de/ns/1.3";
+declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
 declare namespace request = "http://exist-db.org/xquery/request";
 declare namespace xlink = "http://www.w3.org/1999/xlink";
 declare namespace xmldb = "http://exist-db.org/xquery/xmldb";
 
 (: OPTION DECLARATIONS ===================================================== :)
 
-declare option exist:serialize "method=xhtml media-type=text/html omit-xml-declaration=yes indent=yes";
+declare option output:media-type "text/html";
+declare option output:method "xhtml";
+declare option output:indent "yes";
+declare option output:omit-xml-declaration "yes";
 
 (: VARIABLE DECLARATIONS =================================================== :)
 

--- a/add/data/xql/getParts.xql
+++ b/add/data/xql/getParts.xql
@@ -10,12 +10,14 @@ import module namespace eutil = "http://www.edirom.de/xquery/util" at "../xqm/ut
 (: NAMESPACE DECLARATIONS ================================================== :)
 
 declare namespace mei = "http://www.music-encoding.org/ns/mei";
+declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
 declare namespace request = "http://exist-db.org/xquery/request";
 declare namespace xmldb = "http://exist-db.org/xquery/xmldb";
 
 (: OPTION DECLARATIONS ===================================================== :)
 
-declare option exist:serialize "method=text media-type=text/plain omit-xml-declaration=yes";
+declare option output:media-type "text/plain";
+declare option output:method "text";
 
 (: QUERY BODY ============================================================== :)
 

--- a/add/data/xql/getPreferences.xql
+++ b/add/data/xql/getPreferences.xql
@@ -15,11 +15,15 @@ import module namespace edition = "http://www.edirom.de/xquery/edition" at "../x
 
 (: NAMESPACE DECLARATIONS ================================================== :)
 
+declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
 declare namespace request = "http://exist-db.org/xquery/request";
 
 (: OPTION DECLARATIONS ===================================================== :)
 
-declare option exist:serialize "method=xhtml media-type=text/html omit-xml-declaration=yes indent=yes";
+declare option output:media-type "text/html";
+declare option output:method "xhtml";
+declare option output:indent "yes";
+declare option output:omit-xml-declaration "yes";
 
 (: QUERY BODY ============================================================== :)
 

--- a/add/data/xql/getReducedDocument.xql
+++ b/add/data/xql/getReducedDocument.xql
@@ -10,12 +10,17 @@ import module namespace eutil = "http://www.edirom.de/xquery/util" at "../xqm/ut
 
 (: NAMESPACE DECLARATIONS ================================================== :)
 
+declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
 declare namespace request = "http://exist-db.org/xquery/request";
+declare namespace system = "http://exist-db.org/xquery/system";
+declare namespace transform = "http://exist-db.org/xquery/transform";
 
 (: OPTION DECLARATIONS ===================================================== :)
 
-declare option exist:serialize "method=xhtml media-type=text/html omit-xml-declaration=yes indent=yes";
-(:declare option exist:serialize "method=text media-type=text/plain omit-xml-declaration=yes";:)
+declare option output:media-type "text/html";
+declare option output:method "xhtml";
+declare option output:indent "yes";
+declare option output:omit-xml-declaration "yes";
 
 (: VARIABLE DECLARATIONS =================================================== :)
 

--- a/add/data/xql/getRendering.xql
+++ b/add/data/xql/getRendering.xql
@@ -6,6 +6,7 @@ xquery version "3.1";
 (: NAMESPACE DECLARATIONS ================================================== :)
 
 declare namespace mei = "http://www.music-encoding.org/ns/mei";
+declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
 declare namespace request = "http://exist-db.org/xquery/request";
 declare namespace system = "http://exist-db.org/xquery/system";
 declare namespace transform = "http://exist-db.org/xquery/transform";
@@ -13,7 +14,10 @@ declare namespace xmldb = "http://exist-db.org/xquery/xmldb";
 
 (: OPTION DECLARATIONS ===================================================== :)
 
-declare option exist:serialize "method=xhtml media-type=text/html omit-xml-declaration=yes indent=yes";
+declare option output:media-type "text/html";
+declare option output:method "xhtml";
+declare option output:indent "yes";
+declare option output:omit-xml-declaration "yes";
 
 (: QUERY BODY ============================================================== :)
 

--- a/add/data/xql/getSummary.xql
+++ b/add/data/xql/getSummary.xql
@@ -12,13 +12,17 @@ import module namespace eutil = "http://www.edirom.de/xquery/util" at "../xqm/ut
 
 declare namespace edirom_image = "http://www.edirom.de/ns/image";
 declare namespace mei = "http://www.music-encoding.org/ns/mei";
+declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
 declare namespace request = "http://exist-db.org/xquery/request";
 declare namespace tei = "http://www.tei-c.org/ns/1.0";
 declare namespace xmldb = "http://exist-db.org/xquery/xmldb";
 
 (: OPTION DECLARATIONS ===================================================== :)
 
-declare option exist:serialize "method=xhtml media-type=text/html omit-xml-declaration=yes indent=yes";
+declare option output:media-type "text/html";
+declare option output:method "xhtml";
+declare option output:indent "yes";
+declare option output:omit-xml-declaration "yes";
 
 (: VARIABLE DECLARATIONS =================================================== :)
 

--- a/add/data/xql/getWorkID.xql
+++ b/add/data/xql/getWorkID.xql
@@ -16,10 +16,13 @@ import module namespace work = "http://www.edirom.de/xquery/work" at "../xqm/wor
 (: NAMESPACE DECLARATIONS ================================================== :)
 
 declare namespace edirom = "http://www.edirom.de/ns/1.3";
+declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
+declare namespace request = "http://exist-db.org/xquery/request";
 
 (: OPTION DECLARATIONS ===================================================== :)
 
-declare option exist:serialize "method=text media-type=text/plain omit-xml-declaration=yes";
+declare option output:media-type "text/plain";
+declare option output:method "text";
 
 (: QUERY BODY ============================================================== :)
 

--- a/add/data/xql/getWorks.xql
+++ b/add/data/xql/getWorks.xql
@@ -16,11 +16,13 @@ import module namespace work = "http://www.edirom.de/xquery/work" at "../xqm/wor
 
 (: NAMESPACE DECLARATIONS ================================================== :)
 
+declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
 declare namespace request = "http://exist-db.org/xquery/request";
 
 (: OPTION DECLARATIONS ===================================================== :)
 
-declare option exist:serialize "method=text media-type=text/plain omit-xml-declaration=yes";
+declare option output:media-type "text/plain";
+declare option output:method "text";
 
 (: QUERY BODY ============================================================== :)
 

--- a/add/data/xql/getiFrameURL.xql
+++ b/add/data/xql/getiFrameURL.xql
@@ -5,12 +5,13 @@ xquery version "3.1";
 
 (: NAMESPACE DECLARATIONS ================================================== :)
 
+declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
 declare namespace request = "http://exist-db.org/xquery/request";
-declare namespace xmldb = "http://exist-db.org/xquery/xmldb";
 
 (: OPTION DECLARATIONS ===================================================== :)
 
-declare option exist:serialize "method=text media-type=text/plain omit-xml-declaration=yes";
+declare option output:media-type "text/plain";
+declare option output:method "text";
 
 (: QUERY BODY ============================================================== :)
 


### PR DESCRIPTION
## Description, Context and related Issue

This PR replaces all occurrences of the proprietary `exist:serialize` options with the respective serialization options from the [XSLT and XQuery Serialization 3.1 standard](https://www.w3.org/TR/xslt-xquery-serialization-31/).

I tried to stick to the task but couldn't help to adjust some namespace declarations when I spotted some missing declarations or some superfluous ones.

Also, when the output method was "text" I omitted the "omit-xml-declaration" directive since this is not applicable to the text output method.

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Refs #362
