### PR TITLE
replace proprietary exist:serialize options

### DIFF
--- a/add/controller.xql
+++ b/add/controller.xql
@@ -1,14 +1,27 @@
 xquery version "3.1";
 
+(: IMPORTS ================================================================= :)
+
 import module namespace edition="http://www.edirom.de/xquery/edition" at "data/xqm/edition.xqm";
 import module namespace eutil = "http://www.edirom.de/xquery/util" at "data/xqm/util.xqm";
+
+(: NAMESPACE DECLARATIONS ================================================== :)
+
+declare namespace exist="http://exist.sourceforge.net/NS/exist";
+declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
+declare namespace request="http://exist-db.org/xquery/request";
+
+(: OPTION DECLARATIONS ===================================================== :)
+
+declare option output:media-type "application/xhtml+html";
+declare option output:method "xhtml";
+
+(: VARIABLE DECLARATIONS =================================================== :)
 
 declare variable $exist:path external;
 declare variable $exist:resource external;
 declare variable $exist:prefix external;
 declare variable $exist:controller external;
-
-declare option exist:serialize "method=xhtml media-type=application/xhtml+html";
 
 let $langVal := eutil:getLanguage(request:get-parameter("edition", ""))
 

--- a/add/index.xql
+++ b/add/index.xql
@@ -1,14 +1,27 @@
 xquery version "3.1";
 
+(: IMPORTS ================================================================= :)
+
 import module namespace edition = "http://www.edirom.de/xquery/edition" at "data/xqm/edition.xqm";
 
+(: NAMESPACE DECLARATIONS ================================================== :)
+
 declare namespace edirom = "http://www.edirom.de/ns/1.3";
+declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
+declare namespace request = "http://exist-db.org/xquery/request";
+
+(: OPTION DECLARATIONS ===================================================== :)
+
+declare option output:media-type "text/html";
+declare option output:method "html5";
+declare option output:indent "yes";
+declare option output:omit-xml-declaration "yes";
+
+(: VARIABLE DECLARATIONS =================================================== :)
 
 declare variable $edition := request:get-parameter("edition", "");
 declare variable $editionUri := edition:findEdition($edition);
 declare variable $preferences := doc(edition:getPreferencesURI($editionUri));
-
-declare option exist:serialize "method=html5 media-type=text/html omit-xml-declaration=yes indent=yes";
 
 let $eoEditionFiles := collection('/db/apps')//edirom:edition[@xml:id]
 let $eoEditionFilesCount := count($eoEditionFiles)


### PR DESCRIPTION
leftovers from https://github.com/Edirom/Edirom-Online/pull/414 spotted by @bwbohl


<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Refs #362 


### To discuss

The current output method  of `add/controller.xql` ("method=xhtml media-type=application/xhtml+html") seems incorrect to me. In fact, it returns a `<dispatch>` element so it should be considered "method=xml media-type=application/xml". Looking at various eXist apps (eXide, Monex, etc.), those never state the output method explicitly, so I assume they are relying on the default "xml". Only the Dashboard app has something different, yet I consider this an error?
https://github.com/eXist-db/dashboard/blob/35ca2c9d5efc6ac27b28a6bfdb4f499bb622a2d8/controller.xql#L5-L7

Nevertheless, I'm not 100% sure so I copied over the existing media type and output method and put it here for discussion.
