### PR TITLE
capture http graphics URLs instead of folder-ups

### DIFF
--- a/add/data/xslt/tei/profiles/edirom-body/teiBody2HTML.xsl
+++ b/add/data/xslt/tei/profiles/edirom-body/teiBody2HTML.xsl
@@ -150,7 +150,7 @@
         -->
         
         <!-- the graphics prefix will be prepended and should identify relative @urls -->
-        <xsl:variable name="graphicsPrefix">
+        <xsl:variable name="graphicsPrefix" as="xs:string?">
             <xsl:choose>
                 <xsl:when test="starts-with(@url, 'http')">
                     <!-- url starts with http i.e. points to a web accessible location -->

--- a/add/data/xslt/tei/profiles/edirom-body/teiBody2HTML.xsl
+++ b/add/data/xslt/tei/profiles/edirom-body/teiBody2HTML.xsl
@@ -149,7 +149,14 @@
             </xsl:choose>
         -->
         
-        <!-- the graphics prefix will be prepended and should identify relative @urls -->
+        <!-- 
+            The variable `$graphicsPrefix` is to distinguish images (referenced from a TEI file) that are 
+            a) to be fetched from a remote location (via http or https) or 
+            b) from the current EOL instance
+            
+            In the case of a) `$graphicsPrefix` will be the empty-sequence
+            In the case of b) `$graphicsPrefix` will hold a string with the computed URL of the image
+        -->
         <xsl:variable name="graphicsPrefix" as="xs:string?">
             <xsl:choose>
                 <xsl:when test="starts-with(@url, 'http')">

--- a/add/data/xslt/tei/profiles/edirom-body/teiBody2HTML.xsl
+++ b/add/data/xslt/tei/profiles/edirom-body/teiBody2HTML.xsl
@@ -73,9 +73,9 @@
             <xsl:with-param name="implicitBlock" select="$implicitBlock"/>
         </xsl:next-match>
     -->
-    <doc xmlns="http://www.oxygenxml.com/ns/doc/xsl">
-        <desc>Section-like object</desc>
-    </doc>
+    <xd:doc>
+        <xd:desc>Section-like object</xd:desc>
+    </xd:doc>
     <xsl:template name="makeSection">
         <xsl:param name="element"/>
         <xsl:param name="level"/>
@@ -148,11 +148,16 @@
                 </xsl:otherwise>
             </xsl:choose>
         -->
+        
+        <!-- the graphics prefix will be prepended and should identify relative @urls -->
         <xsl:variable name="graphicsPrefix">
             <xsl:choose>
-                <xsl:when test="starts-with(@url, '../')">
-                    <xsl:value-of select="$contextPath || '/' || substring-after(functx:substring-before-last($docUri, '/'), 'xmldb:exist:///db/') || '/'"/>
+                <xsl:when test="starts-with(@url, 'http')">
+                    <!-- url starts with http i.e. points to a web accessible location -->
                 </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="$contextPath || '/' || substring-after(functx:substring-before-last($docUri, '/'), 'xmldb:exist:///db/') || '/'"/>
+                </xsl:otherwise>
             </xsl:choose>
         </xsl:variable>
         <!-- /Edirom Online specific cutomization -->


### PR DESCRIPTION
## Description, Context and related Issue
<!--- Please describe your changes. Why is this change required? What problem does it solve? -->
Instead of capturing folder-ups in relative graphics URLs the transfromation now captures web-accessible graphic URLS starting with `http` and excludes them from prepending the current docs URI

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
closes #421

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
BAZ-GA internal edition

## Types of changes
<!--- What types of changes does your code introduce? Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
<!--- Go over all the following points, and delete options that are not relevant. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online/blob/develop/CONTRIBUTING.md) document.

