### PR TITLE
Make `eutil:getPreference#2` and `edition:getPreferencesURI#1` more robust

### DIFF
--- a/add/data/xql/getPreferences.xql
+++ b/add/data/xql/getPreferences.xql
@@ -32,7 +32,7 @@ let $edition := request:get-parameter('edition', '')
 
 (:let $base := concat('file:', system:get-module-load-path()):)
 (:let $file := doc(concat($base, '/../prefs/edirom-prefs.xml')):)
-let $file := doc('../prefs/edirom-prefs.xml')
+let $file := doc($edition:default-prefs-location)
 
 let $projectFile := doc(edition:getPreferencesURI($edition))
 

--- a/add/data/xql/getPreferences.xql
+++ b/add/data/xql/getPreferences.xql
@@ -30,8 +30,6 @@ declare option output:omit-xml-declaration "yes";
 let $mode := request:get-parameter('mode', '')
 let $edition := request:get-parameter('edition', '')
 
-(:let $base := concat('file:', system:get-module-load-path()):)
-(:let $file := doc(concat($base, '/../prefs/edirom-prefs.xml')):)
 let $file := doc($edition:default-prefs-location)
 
 let $projectFile := doc(edition:getPreferencesURI($edition))

--- a/add/data/xqm/edition.xqm
+++ b/add/data/xqm/edition.xqm
@@ -122,16 +122,15 @@ declare function edition:getLanguageCodesSorted($uri as xs:string) as xs:string 
 };
 
 (:~
- : Returns the URI for the preferences file
+ : Returns the URI of the preferences file for a given edition
  :
  : @param $uri The URI of the Edition's document to process
- : @return The URI of the preference file
+ : @return The URI of the edition's preference file or the default edirom preferences as fallback
  :)
-declare function edition:getPreferencesURI($uri as xs:string) as xs:string {
-    
-    if(doc($uri)//edirom:preferences/@xlink:href => string()) then(
-        doc($uri)//edirom:preferences/@xlink:href => string()
-    ) else ('../prefs/edirom-prefs.xml')
+declare function edition:getPreferencesURI($uri as xs:string?) as xs:string {
+    if(doc-available($uri) and doc($uri)//edirom:preferences/@xlink:href => string()) 
+    then(doc($uri)//edirom:preferences/@xlink:href => string()) 
+    else $edition:default-prefs-location
 };
 
 (:~

--- a/add/data/xqm/edition.xqm
+++ b/add/data/xqm/edition.xqm
@@ -19,6 +19,10 @@ import module namespace functx="http://www.functx.com";
 declare namespace edirom = "http://www.edirom.de/ns/1.3";
 declare namespace xlink = "http://www.w3.org/1999/xlink";
 
+(: VARIABLE DECLARATIONS =================================================== :)
+
+declare variable $edition:default-prefs-location as xs:string := '../prefs/edirom-prefs.xml';
+
 (: FUNCTION DECLARATIONS =================================================== :)
 
 (:~

--- a/add/data/xqm/util.xqm
+++ b/add/data/xqm/util.xqm
@@ -279,21 +279,20 @@ declare function eutil:getLanguageString($key as xs:string, $values as xs:string
 };
 
 (:~
- : Return a value of preference to key
+ : Returns a value from the preferences for a given key
  :
- : @param $key The key to search for
- : @return The string
+ : @param $key The key to look up
+ : @param $edition The current edition URI
+ : @return The preference value
  :)
 declare function eutil:getPreference($key as xs:string, $edition as xs:string?) as xs:string {
 
-    let $file := doc('../prefs/edirom-prefs.xml')
-    let $projectFile := doc(edition:getPreferencesURI($edition))
+    let $preferencesFile := 
+        try { doc(edition:getPreferencesURI($edition)) }
+        catch * { util:log-system-out('Failed to load preferences') }
 
     return
-        if($projectFile != 'null' and $projectFile//entry[@key = $key]) then
-            ($projectFile//entry[@key = $key]/string(@value))
-        else
-            ($file//entry[@key = $key]/string(@value))
+        $preferencesFile//entry[@key = $key]/@value => string()
 
 };
 


### PR DESCRIPTION
## Description, Context and related Issue
<!--- Please describe your changes. Why is this change required? What problem does it solve? -->

The function `eutil:getPreference#2` has an optional parameter `$edition` but is calling `edition:getPreferencesURI($edition)` where the function parameter is not optional but required.
So, if `eutil:getPreference#2` is called with an empty `$edition` parameter  an error is thrown by `edition:getPreferencesURI#1`:
```
javax.servlet.ServletException: javax.servlet.ServletException: An error occurred while processing request to /index.html: exerr:ERROR The actual return type does not match the sequence type declared in the function's signature: edition:getPreferencesURI(xs:string) xs:string. Expected cardinality: exactly one, got 0. [at line 93, column 43, source: /db/apps/Edirom-Online/data/xqm/util.xqm]
```

I separated out the various steps into four commits and added (hopefully) appropriate documentation to the individual commits.

## How Has This Been Tested?

Tested locally

## Types of changes
<!--- What types of changes does your code introduce? Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation Update

## Checklist
<!--- Go over all the following points, and delete options that are not relevant. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have performed a self-review of my code
- [x] I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online/blob/develop/CONTRIBUTING.md) document.

