### PR TITLE
Fix/279 start documents uri not found

### DIFF
--- a/app/Application.js
+++ b/app/Application.js
@@ -182,7 +182,7 @@ Ext.define('EdiromOnline.Application', {
     
     openStartDocuments: function() {
         var me = this;
-        var uris = me.getController('PreferenceController').getPreference('start_documents_uri');
+        var uris = me.getController('PreferenceController').getPreference('start_documents_uri', true);
         if(uris){
             window.loadLink(uris);
         }

--- a/app/Application.js
+++ b/app/Application.js
@@ -183,6 +183,8 @@ Ext.define('EdiromOnline.Application', {
     openStartDocuments: function() {
         var me = this;
         var uris = me.getController('PreferenceController').getPreference('start_documents_uri');
-        window.loadLink(uris);
+        if(uris){
+            window.loadLink(uris);
+        }
     }
 });

--- a/app/controller/PreferenceController.js
+++ b/app/controller/PreferenceController.js
@@ -64,6 +64,7 @@ Ext.define('EdiromOnline.controller.PreferenceController', {
     getPreference: function(key, lax) {
         var me = this;
 
+        // if key does not exist but lax is true, return null
         if(!me.preferences[key] && lax)
             return null;
         
@@ -81,19 +82,12 @@ Ext.define('EdiromOnline.controller.PreferenceController', {
         }
 
         if(!me.preferences[key]) {
-
-            // ignore errors for these keys
-            ignoredKeys = [ "start_documents_uri" ];
-
-            // throw an error only if the key is not in the ignoredKeys array
-            if(!ignoredKeys.includes(key)){
-                Ext.Error.raise({
-                    msg: 'No preference found with that key',
-                    key: key,
-                    level: 'warn' //warn, error, fatal
-                });
-            }            
-
+            Ext.Error.raise({
+                msg: 'No preference found with this key',
+                key: key,
+                level: 'warn' //warn, error, fatal
+            });
+        
             return null;
         }
 

--- a/app/controller/PreferenceController.js
+++ b/app/controller/PreferenceController.js
@@ -86,9 +86,9 @@ Ext.define('EdiromOnline.controller.PreferenceController', {
             ignoredKeys = [ "start_documents_uri" ];
 
             // throw an error only if the key is not in the ignoredKeys array
-            if(!ignoredKeys.indexOf(key) > -1){
+            if(!ignoredKeys.includes(key)){
                 Ext.Error.raise({
-                    msg: 'No preference found with this key',
+                    msg: 'No preference found with that key',
                     key: key,
                     level: 'warn' //warn, error, fatal
                 });

--- a/app/controller/PreferenceController.js
+++ b/app/controller/PreferenceController.js
@@ -81,11 +81,18 @@ Ext.define('EdiromOnline.controller.PreferenceController', {
         }
 
         if(!me.preferences[key]) {
-            Ext.Error.raise({
-                msg: 'No preference found with this key',
-                key: key,
-                level: 'warn' //warn, error, fatal
-            });
+
+            // ignore errors for these keys
+            ignoredKeys = [ "start_documents_uri" ];
+
+            // throw an error only if the key is not in the ignoredKeys array
+            if(!ignoredKeys.indexOf(key) > -1){
+                Ext.Error.raise({
+                    msg: 'No preference found with this key',
+                    key: key,
+                    level: 'warn' //warn, error, fatal
+                });
+            }            
 
             return null;
         }


### PR DESCRIPTION
## Description, Context and related Issue
When key start_documents_uri is no provided in prefs file, then an error message was thrown to the logs, which can be seen as too verbose. Some conditions were introduced to prevent the error message for this key. Can be extended to more keys if desired. 

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Refs #279 

## How Has This Been Tested?
Built and deployed Edirom with EditionExample. No error on console anymore.

## Types of changes
<!--- What types of changes does your code introduce? Please delete options that are not relevant. -->
- New feature (non-breaking change which adds functionality)

## Checklist
<!--- Go over all the following points, and delete options that are not relevant. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- I have performed a self-review of my code
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online/blob/develop/CONTRIBUTING.md) document.
- All new and existing tests passed.
