### PR TITLE
fix ReferenceError when `debug` is not defined

### DIFF
--- a/app/controller/window/source/MeasureBasedView.js
+++ b/app/controller/window/source/MeasureBasedView.js
@@ -157,13 +157,13 @@ Ext.define('EdiromOnline.controller.window.source.MeasureBasedView', {
         var me = this;
         
 
-        if(debug !== null && debug) {
+        if(typeof(debug) !== 'undefined' && debug !== null && debug) {
             console.log('controller: MeasureBasedView: onAnnotationsVisibilityChange');
         }
 
         if(visible) {
 
-            if(debug !== null && debug) {
+            if(typeof(debug) !== 'undefined' && debug !== null && debug) {
                 console.log('visible: ' + visible);
             }
 
@@ -187,7 +187,7 @@ Ext.define('EdiromOnline.controller.window.source.MeasureBasedView', {
             );
         }else {
 
-            if(debug !== null && debug) {
+            if(typeof(debug) !== 'undefined' && debug !== null && debug) {
                 console.log('visible: ' + visible);
             }
 

--- a/app/controller/window/source/SourceView.js
+++ b/app/controller/window/source/SourceView.js
@@ -37,7 +37,7 @@ Ext.define('EdiromOnline.controller.window.source.SourceView', {
     onSourceViewRendered: function(view) {
         var me = this;
 
-        if(debug !== null && debug) {
+        if(typeof(debug) !== 'undefined' && debug !== null && debug) {
             console.log('Controller: SourceView: onSourceViewRendered');
         }
 
@@ -57,7 +57,7 @@ Ext.define('EdiromOnline.controller.window.source.SourceView', {
         ToolsController.addAnnotationVisibilityListener(view.id, Ext.bind(view.checkGlobalAnnotationVisibility, view));
         view.checkGlobalAnnotationVisibility(ToolsController.areAnnotationsVisible());
 
-        if(debug !== null && debug) {
+        if(typeof(debug) !== 'undefined' && debug !== null && debug) {
             console.log('Controller: SourceView: onSourceViewRendered. getMovements');
         }
         window.doAJAXRequest('data/xql/getMovements.xql',
@@ -77,7 +77,7 @@ Ext.define('EdiromOnline.controller.window.source.SourceView', {
             }, this)
         );
 
-        if(debug !== null && debug) {
+        if(typeof(debug) !== 'undefined' && debug !== null && debug) {
             console.log('Controller: SourceView: onSourceViewRendered: getAnnotationInfos');
         }
 
@@ -93,7 +93,7 @@ Ext.define('EdiromOnline.controller.window.source.SourceView', {
 
                 data = Ext.JSON.decode(data);
 
-                if(debug !== null && debug) {
+                if(typeof(debug) !== 'undefined' && debug !== null && debug) {
                     console.log(data);
                 }
 
@@ -210,13 +210,13 @@ Ext.define('EdiromOnline.controller.window.source.SourceView', {
     onAnnotationsVisibilityChange: function(view, visible) {
         var me = this;
 
-        if(debug !== null && debug) {
+        if(typeof(debug) !== 'undefined' && debug !== null && debug) {
             console.log('controller: SourceView: onAnnotationsVisibilityChange');
         }
 
         if(visible) {
 
-            if(debug !== null && debug) {
+            if(typeof(debug) !== 'undefined' && debug !== null && debug) {
                 console.log('visible: ' + visible);
             }
 

--- a/app/view/window/image/OpenSeaDragonViewer.js
+++ b/app/view/window/image/OpenSeaDragonViewer.js
@@ -247,7 +247,7 @@ Ext.define('EdiromOnline.view.window.image.OpenSeaDragonViewer', {
 
     removeShapes: function(groupName) {
 
-        if(debug !== null && debug) {
+        if(typeof(debug) !== 'undefined' && debug !== null && debug) {
             console.log('view: OpenSeaDragonView: removeShapes');
             console.log(groupName);
         }
@@ -256,7 +256,7 @@ Ext.define('EdiromOnline.view.window.image.OpenSeaDragonViewer', {
 
         //abort if me.shapes does not contain key
         if(!me.shapes.containsKey(groupName)) {
-            if(debug !== null && debug) {
+            if(typeof(debug) !== 'undefined' && debug !== null && debug) {
                 console.log('me.shapes does not contain key: ' + groupName);
             }
             return;
@@ -273,7 +273,7 @@ Ext.define('EdiromOnline.view.window.image.OpenSeaDragonViewer', {
                 id = shape.id;
             }
 
-            if(debug !== null && debug) {
+            if(typeof(debug) !== 'undefined' && debug !== null && debug) {
                 console.log('me.id: ' + me.id);
                 console.log('+shape.id: ' + me.id + '_' + id);
             }
@@ -314,7 +314,7 @@ Ext.define('EdiromOnline.view.window.image.OpenSeaDragonViewer', {
 
         var me = this;
 
-        if(debug !== null && debug) {
+        if(typeof(debug) !== 'undefined' && debug !== null && debug) {
             console.log('controller: OpenseaDragonView: addAnnotaitons');
             console.log('annotations RAW');
             console.log(annotations);
@@ -329,7 +329,7 @@ Ext.define('EdiromOnline.view.window.image.OpenSeaDragonViewer', {
         //var tpl = dh.createTemplate('<div id="{0}" class="annotation {2} {3} {4}" data-edirom-annot-id="{4}"><div id="{0}_inner" class="annotIcon" title="{1}"></div></div>');
         //tpl.compile();
 
-        if(debug !== null && debug) {
+        if(typeof(debug) !== 'undefined' && debug !== null && debug) {
             console.log('me.shapes annotations');
             console.log(me.shapes.get('annotations'));
         }
@@ -337,7 +337,7 @@ Ext.define('EdiromOnline.view.window.image.OpenSeaDragonViewer', {
         // iterate over annotations
         annotations.each(function(annotation) {
 
-            if(debug !== null && debug) {
+            if(typeof(debug) !== 'undefined' && debug !== null && debug) {
                 console.log('Processing annotation…');
                 console.log(annotation);
             }
@@ -446,7 +446,7 @@ Ext.define('EdiromOnline.view.window.image.OpenSeaDragonViewer', {
                     }
                 }, tip);
             });
-            if(debug !== null && debug) {
+            if(typeof(debug) !== 'undefined' && debug !== null && debug) {
                 console.log('me.shapes annotations');
                 console.log(me.shapes.get('annotations'));
             }
@@ -462,7 +462,7 @@ Ext.define('EdiromOnline.view.window.image.OpenSeaDragonViewer', {
 
     getShapeElem: function(shapeId) {
 
-        if(debug !== null && debug) {
+        if(typeof(debug) !== 'undefined' && debug !== null && debug) {
             console.log('view: OpenSeaDragonView: getShapeElem: ' + shapeId);
         }
         var me = this;

--- a/app/view/window/source/PageBasedView.js
+++ b/app/view/window/source/PageBasedView.js
@@ -69,7 +69,7 @@ Ext.define('EdiromOnline.view.window.source.PageBasedView', {
 
         var me = this;
 
-        if(debug !== null && debug) {
+        if(typeof(debug) !== 'undefined' && debug !== null && debug) {
             console.log('View: PageBasedView: annotationFilterChanged');
             console.log('visibleCategories');
             console.log(visibleCategories);
@@ -82,7 +82,7 @@ Ext.define('EdiromOnline.view.window.source.PageBasedView', {
 
         var annotations = me.imageViewer.getShapes('annotations');
 
-        if(debug !== null && debug) {
+        if(typeof(debug) !== 'undefined' && debug !== null && debug) {
             console.log('View: PageBasedView: annotationFilterChanged: annotations');
             console.log(annotations);
             console.log(me.imageViewer.shapes.get('annotations'));
@@ -105,7 +105,7 @@ Ext.define('EdiromOnline.view.window.source.PageBasedView', {
             Ext.Array.remove(prioritiesCategories, 'measure');
             Ext.Array.remove(prioritiesCategories, 'annoIcon');
 
-            if(debug !== null && debug) {
+            if(typeof(debug) !== 'undefined' && debug !== null && debug) {
                 console.log('View: PageBasedView: annotationFilterChanged: annotations fn');
                 console.log(annotationId);
                 console.log(annotDiv);
@@ -124,7 +124,7 @@ Ext.define('EdiromOnline.view.window.source.PageBasedView', {
                 matchesPriorityFilter |= Ext.Array.contains(visiblePriorities, prioritiesCategories[i]);
             }
 
-            if(debug !== null && debug) {
+            if(typeof(debug) !== 'undefined' && debug !== null && debug) {
                 console.log(matchesCategoryFilter);
                 console.log(matchesPriorityFilter);
             }
@@ -151,7 +151,7 @@ Ext.define('EdiromOnline.view.window.source.PageBasedView', {
 
         Ext.Array.each(annotations, function(annotation) {
 
-            if(debug !== null && debug) {
+            if(typeof(debug) !== 'undefined' && debug !== null && debug) {
                 console.log('annotation');
                 console.log(annotation);
                 console.log('me');
@@ -167,7 +167,7 @@ Ext.define('EdiromOnline.view.window.source.PageBasedView', {
             Ext.Array.push(annotationDivIds, Ext.Array.pluck(children, 'id'));
         });
 
-        if(debug !== null && debug) {
+        if(typeof(debug) !== 'undefined' && debug !== null && debug) {
             console.log(annotationDivIds);
         }
 

--- a/app/view/window/source/SourceView.js
+++ b/app/view/window/source/SourceView.js
@@ -146,7 +146,7 @@ Ext.define('EdiromOnline.view.window.source.SourceView', {
     setAnnotationFilter: function(priorities, categories) {
         var me = this;
 
-        if(debug !== null && debug) {
+        if(typeof(debug) !== 'undefined' && debug !== null && debug) {
             console.log('View: SourceView: setAnnotationFilter');
             console.log('priorities');
             console.log(priorities);


### PR DESCRIPTION
## Description, Context and related Issue

If no `debug` variable is set, there are some `ReferenceErrors`. The fix checks whether the variable is declared.

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Refs #443

## How Has This Been Tested?

I have installed the default branch with the fix and with the data of the clarinet quintet in an exist-db. If you then open the autograph, the error does not appear any more.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my code
- [x] I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online/blob/develop/CONTRIBUTING.md) document.
