### PR TITLE
Bug/432 go to measure… function returns wrong measure

### DIFF
--- a/add/data/xql/getMeasurePage.xql
+++ b/add/data/xql/getMeasurePage.xql
@@ -25,6 +25,7 @@ declare function local:findMeasure($mei, $movementId, $measureIdName) as element
             ($m)
         else
          (($mei/id($movementId)//mei:measure[@label eq $measureIdName], $mei/id($movementId)//mei:measure[@n eq $measureIdName])[1]) 
+}
 declare function local:getMeasure($mei, $measure, $movementId) as map(*) {
     let $measureId := $measure/string(@xml:id)
     let $zoneId := substring-after($measure/string(@facs), '#')

--- a/add/data/xql/getMeasurePage.xql
+++ b/add/data/xql/getMeasurePage.xql
@@ -24,9 +24,7 @@ declare function local:findMeasure($mei, $movementId, $measureIdName) as element
         if ($m) then
             ($m)
         else
-            (($mei/id($movementId)//mei:measure[@n eq $measureIdName])[1])
-};
-
+         (($mei/id($movementId)//mei:measure[@label eq $measureIdName], $mei/id($movementId)//mei:measure[@n eq $measureIdName])[1]) 
 declare function local:getMeasure($mei, $measure, $movementId) as map(*) {
     let $measureId := $measure/string(@xml:id)
     let $zoneId := substring-after($measure/string(@facs), '#')


### PR DESCRIPTION
## Description, Context and related Issue
<!--- Please describe your changes. Why is this change required? What problem does it solve? -->
This PR is a quick fix for the issue 432.  Change the code [on line number ](https://github.com/Edirom/Edirom-Online/commit/e6c24303e75f0b8e4cf037631306e9c53971d858#diff-11ca3497e203008800617bf27e9109f5234eca41d0e5a7452e35a91e94fc494fR27) to https://github.com/Edirom/Edirom-Online/commit/e6c24303e75f0b8e4cf037631306e9c53971d858#diff-11ca3497e203008800617bf27e9109f5234eca41d0e5a7452e35a91e94fc494fR27 will look for the first <measure> element within a specified movement ($movementId) where either: the @label attribute equals $measureIdName, or, the @n attribute equals $measureIdName other than relaying only on @n.
<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Refs #
#432 

## How Has This Been Tested?
Tasted on weber klarinettenquintett.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->

## Types of changes
<!--- What types of changes does your code introduce? Please delete options that are not relevant. -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update

## Checklist
<!--- Go over all the following points, and delete options that are not relevant. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X] I have performed a self-review of my code
- [ X] I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online/blob/develop/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ X] All new and existing tests passed.
