### PR TITLE
Fix: handling for works encoded with mei4+ in getLinkTarget

### DIFF
--- a/add/data/xql/getLinkTarget.xql
+++ b/add/data/xql/getLinkTarget.xql
@@ -157,7 +157,7 @@ declare function local:getViews($type as xs:string, $docUri as xs:string, $doc a
 declare function local:getWindowTitle($doc as node()+, $type as xs:string) as xs:string {
     
     (: Work :)
-    if (exists($doc//mei:mei) and exists($doc//mei:workDesc/mei:work) and not(exists($doc//mei:perfMedium))) then
+    if (exists($doc//mei:mei) and exists($doc//(mei:workDesc|mei:workList)/mei:work) and not(exists($doc//mei:perfMedium))) then
         (eutil:getLocalizedTitle(($doc//mei:work)[1]/mei:titleStmt[1], $lang))
     else if (exists($doc/root()/mei:work)) then
         (eutil:getLocalizedTitle($doc/root()/mei:work, $lang))


### PR DESCRIPTION
## Description, Context and related Issue
I extended the XPath to make shure that work titles of MEI4+ files can also be found.

Closes #337 

## How Has This Been Tested?
eXist-db 6.2.0 by manipulating data in the database.

## Types of changes
- Bug fix (non-breaking change which fixes an issue)