### PR TITLE
Update test

### DIFF
--- a/testing/XQSuite/eutil-tests.xqm
+++ b/testing/XQSuite/eutil-tests.xqm
@@ -27,7 +27,7 @@ declare
         <identifier>P1-PA<rend rend='sup'>1</rend></identifier> – Autographe Partitur</title>
         <title type='main'>Autographe Partitur</title>
         <title type='sub'>Manifestation</title></titleStmt>", 
-        "de")       %test:assertEquals("unknown") %test:pending("Ticket https://github.com/Edirom/Edirom-Online/issues/103")
+        "de")       %test:assertEquals("P1-PA1 – Autographe Partitur")
     %test:args("<titleStmt xmlns='http://www.tei-c.org/ns/1.0'>
         <title type='main'>Autographe Partitur</title>
         <title type='sub'>Manifestation</title></titleStmt>", 


### PR DESCRIPTION
with issue #103 being closed the "pending" annotation can be removed from the test and the proper result added.

I assume that the output of abbreviated titles is on purpose?
So, given this input:
```xml
<titleStmt xmlns='http://www.tei-c.org/ns/1.0'>
    <?prüfen?>
    <title type='abbreviated'><identifier>P1-PA<rend rend='sup'>1</rend></identifier> – Autographe Partitur</title>
    <title type='main'>Autographe Partitur</title>
    <title type='sub'>Manifestation</title>
</titleStmt>
```

the output of `eutil:getLocalizedTitle#2` will be "P1-PA1 – Autographe Partitur".

Refs #103

## How Has This Been Tested?
by running the test XQunit suite manually

## Types of changes
- Documentation Update

## Overview
- I have updated the inline documentation accordingly.
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online/blob/develop/CONTRIBUTING.md) document.
- I have added tests to cover my changes at [testing](https://github.com/Edirom/Edirom-Online/tree/develop/testing)
- All new and existing tests passed.
