### PR TITLE
replace `collection` calls with dedicated function `edition:collection#1`

### DIFF
--- a/add/data/xql/getAnnotationInfos.xql
+++ b/add/data/xql/getAnnotationInfos.xql
@@ -7,33 +7,27 @@ xquery version "3.1";
 (: IMPORTS ================================================================= :)
 
 import module namespace annotation = "http://www.edirom.de/xquery/annotation" at "../xqm/annotation.xqm";
-
+import module namespace edition = "http://www.edirom.de/xquery/edition" at "../xqm/edition.xqm";
 import module namespace eutil = "http://www.edirom.de/xquery/eutil" at "../xqm/eutil.xqm";
 
 
 (: NAMESPACE DECLARATIONS ================================================== :)
 
 declare namespace mei = "http://www.music-encoding.org/ns/mei";
-
 declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
-
 declare namespace request = "http://exist-db.org/xquery/request";
 
 
 (: OPTION DECLARATIONS ===================================================== :)
 
 declare option output:method "json";
-
 declare option output:media-type "application/json";
 
 
 (: VARIABLE DECLARATIONS =================================================== :)
 
 declare variable $uri := request:get-parameter('uri', '');
-
 declare variable $edition := request:get-parameter('edition', '');
-
-declare variable $edition_path := eutil:getPreference('edition_path', $edition);
 
 
 (: FUNCTION DECLARATIONS =================================================== :)
@@ -89,13 +83,13 @@ declare function local:getDistinctPriorities($annots as element()*) as xs:string
 
 (: QUERY BODY ============================================================== :)
 
-let $mei := doc($uri)/root()
-
-let $annots := collection($edition_path)//mei:annot[matches(@plist, $uri)] | $mei//mei:annot
+let $mei := doc($uri)
+let $editionCollection := edition:collection($edition_path)
+let $annots := $editionCollection//mei:annot[matches(@plist, $uri)] | $mei//mei:annot
 
 let $categories :=
     for $category in local:getDistinctCategories($annots)
-    let $categoryElement := (collection($edition_path)/id($category)[mei:label or mei:name])[1]
+    let $categoryElement := ($editionCollection/id($category)[mei:label or mei:name])[1]
     let $name := annotation:category_getName($categoryElement, eutil:getLanguage($edition))
     order by $name
     return
@@ -106,7 +100,7 @@ let $categories :=
 
 let $prios :=
     for $priority in local:getDistinctPriorities($annots)
-    let $name := annotation:getPriorityLabel((collection($edition_path)//id($priority)[mei:label or mei:name])[1])
+    let $name := annotation:getPriorityLabel(($editionCollection/id($priority)[mei:label or mei:name])[1])
     order by $name
     return
         map {

--- a/add/data/xql/getAnnotationInfos.xql
+++ b/add/data/xql/getAnnotationInfos.xql
@@ -84,7 +84,7 @@ declare function local:getDistinctPriorities($annots as element()*) as xs:string
 (: QUERY BODY ============================================================== :)
 
 let $mei := doc($uri)
-let $editionCollection := edition:collection($edition_path)
+let $editionCollection := edition:collection($edition)
 let $annots := $editionCollection//mei:annot[matches(@plist, $uri)] | $mei//mei:annot
 
 let $categories :=

--- a/add/data/xql/getAnnotationsOnPage.xql
+++ b/add/data/xql/getAnnotationsOnPage.xql
@@ -15,30 +15,24 @@ xquery version "3.1";
 
 import module namespace functx = "http://www.functx.com";
 
+import module namespace edition = "http://www.edirom.de/xquery/edition" at "../xqm/edition.xqm";
 import module namespace eutil = "http://www.edirom.de/xquery/eutil" at "../xqm/eutil.xqm";
 
 
 (: NAMESPACE DECLARATIONS ================================================== :)
 
 declare namespace ft = "http://exist-db.org/xquery/lucene";
-
 declare namespace mei = "http://www.music-encoding.org/ns/mei";
-
 declare namespace output = "http://www.w3.org/2010/xslt-xquery-serialization";
-
 declare namespace request = "http://exist-db.org/xquery/request";
-
 declare namespace svg = "http://www.w3.org/2000/svg";
-
 declare namespace xlink = "http://www.w3.org/1999/xlink";
-
 declare namespace xmldb = "http://exist-db.org/xquery/xmldb";
 
 
 (: OPTION DECLARATIONS ===================================================== :)
 
 declare option output:method "json";
-
 declare option output:media-type "application/json";
 
 
@@ -108,7 +102,7 @@ declare function local:findAnnotations($edition as xs:string, $uri as xs:string,
     
     (: TODO: search in other documents and in other collections :)
     (: TODO: check if annotations hold URIs or IDRefs :)
-    let $annots := collection(eutil:getPreference('edition_path', $edition))//mei:annot
+    let $annots := edition:collection($edition)//mei:annot
     let $ret :=
         for $id in $elemIds
         

--- a/add/data/xqm/annotation.xqm
+++ b/add/data/xqm/annotation.xqm
@@ -100,7 +100,7 @@ declare function annotation:toJSON($anno as element(), $edition as xs:string) as
             if(doc-available($p)) then
                 (doc($p))
             else
-                (collection(eutil:getPreference('edition_path', $edition))//id($p)/root())
+                edition:collection($edition)/id($p)/root()
         return
             if ($pDoc//mei:sourceDesc/mei:source/mei:identifier[@type = 'siglum']) then
                 ($pDoc//mei:sourceDesc/mei:source/mei:identifier[@type = 'siglum']/text())


### PR DESCRIPTION
## Description, Context and related Issue
This PR replaces all direct calls to the `collection` function with the new dedicated function `edition:collection#1` so all error handling, improvements, etc. can be done at this central location.

This implements #437

## How Has This Been Tested?
Tested with clarinet quintet

## Types of changes
- Improvement
- Refactoring

## Overview
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online/blob/develop/CONTRIBUTING.md) document.
- All new and existing tests passed.
