### PR TITLE
fix getLinkTarget for MEI 5 work titles

### DIFF
--- a/add/data/xql/getLinkTarget.xql
+++ b/add/data/xql/getLinkTarget.xql
@@ -194,8 +194,8 @@ declare function local:getWindowTitle($doc as document-node()?, $type as xs:stri
         (eutil:getLocalizedTitle($doc//tei:fileDesc/tei:titleStmt[1], $lang))
     
     (: HTML :)
-    else if ($type = 'html') then
-        ($doc//head/data(title))
+    else if ($type = 'html' and not(functx:all-whitespace($doc//*:head/*:title))) then
+        $doc//*:head/*:title => normalize-space()
     
     else if($type = 'unknown') then
     

--- a/add/data/xql/getLinkTarget.xql
+++ b/add/data/xql/getLinkTarget.xql
@@ -173,11 +173,13 @@ declare function local:getWindowTitle($doc as node()+, $type as xs:string) as xs
     else if ($type = 'recording') then
         (eutil:getLocalizedTitle($doc//mei:fileDesc/mei:titleStmt[1], $lang))
     
-    (: Source / Score :)
+    (: Source / Score  MEI 4 and newer :)
     else if ($type = 'source' and exists($doc//mei:manifestation/mei:titleStmt)) then
         (string-join((eutil:getLocalizedTitle(($doc//mei:manifestation)[1]/mei:titleStmt[1], $lang),
         ($doc//mei:manifestation)[1]//mei:identifier[lower-case(@type) = 'shelfmark'][1]), ' | ')
         => normalize-space())
+     
+     (: Source / Score  MEI 3 and older :)
     else if ($type = 'source' and exists($doc//mei:source/mei:titleStmt)) then
         (string-join((eutil:getLocalizedTitle(($doc//mei:source)[1]/mei:titleStmt[1], $lang),
         ($doc//mei:source)[1]//mei:identifier[lower-case(@type) = 'shelfmark'][1]), ' | ')

--- a/add/data/xql/getLinkTarget.xql
+++ b/add/data/xql/getLinkTarget.xql
@@ -185,6 +185,10 @@ declare function local:getWindowTitle($doc as node()+, $type as xs:string) as xs
         ($doc//mei:source)[1]//mei:identifier[lower-case(@type) = 'shelfmark'][1]), ' | ')
         => normalize-space())
     
+    (: MEI fallback if no title is found :)
+    else if (exists($doc//mei:mei) and exists(($doc//mei:titleStmt)[1])) then
+        (eutil:getLocalizedTitle(($doc//mei:titleStmt)[1], $lang))
+
     (: Text :)
     else if ($type = 'text') then
         (eutil:getLocalizedTitle($doc//tei:fileDesc/tei:titleStmt[1], $lang))
@@ -195,10 +199,10 @@ declare function local:getWindowTitle($doc as node()+, $type as xs:string) as xs
     
     else if($type = 'unknown') then
     
-        let $eventualTitleContainers := ($doc//mei:titleStmt, $doc/tei:titleStmt)
+        let $eventualTitleContainers := ($doc//mei:titleStmt, $doc//tei:titleStmt)
         let $eventualTitles := (
             for $et in $eventualTitleContainers return
-                eutil:getLocalizedTitle($eventualTitleContainers[1], $lang),
+                eutil:getLocalizedTitle($et, $lang),
             for $t in $doc//*:title return
                 $t => normalize-space()
         )

--- a/add/data/xql/getLinkTarget.xql
+++ b/add/data/xql/getLinkTarget.xql
@@ -206,7 +206,7 @@ declare function local:getWindowTitle($doc as node()+, $type as xs:string) as xs
         return $eventualTitles[1]
     
     else
-        (string('unknown'))
+        ('[No title found!]')
 };
 
 (: QUERY BODY ============================================================== :)

--- a/add/data/xql/getLinkTarget.xql
+++ b/add/data/xql/getLinkTarget.xql
@@ -154,7 +154,7 @@ declare function local:getViews($type as xs:string, $docUri as xs:string, $doc a
 (:~
  : Returns the window title for an edirom-object
  :)
-declare function local:getWindowTitle($doc as node()+, $type as xs:string) as xs:string {
+declare function local:getWindowTitle($doc as node(), $type as xs:string) as xs:string {
     
     (: Work :)
     if ($type = 'work') then

--- a/add/data/xql/getLinkTarget.xql
+++ b/add/data/xql/getLinkTarget.xql
@@ -158,8 +158,16 @@ declare function local:getWindowTitle($doc as node()+, $type as xs:string) as xs
     
     (: Work :)
     if ($type = 'work') then
-    (: will fail for MEI v3 or older :)
-        eutil:getLocalizedTitle(($doc//mei:work)[1], $lang)
+        
+        let $workTitleContainer := (
+            (: MEI 3 and older :)
+            ($doc//mei:work)[1]/mei:titleStmt,
+            (: MEI 4 and newer :)
+            ($doc//mei:work)[1]
+        )[1]
+    
+        return
+            eutil:getLocalizedTitle($workTitleContainer, $lang)
     
     (: Recording :)
     else if (exists($doc//mei:mei) and exists($doc//mei:recording)) then

--- a/add/data/xql/getLinkTarget.xql
+++ b/add/data/xql/getLinkTarget.xql
@@ -157,7 +157,7 @@ declare function local:getViews($type as xs:string, $docUri as xs:string, $doc a
 declare function local:getWindowTitle($doc as node()+, $type as xs:string) as xs:string {
     
     (: Work :)
-    if (exists($doc//mei:mei) and exists($doc//(mei:workDesc|mei:workList)/mei:work) and not(exists($doc//mei:perfMedium))) then
+    if ($type = 'work') then
         (eutil:getLocalizedTitle((($doc//mei:work)[1]//mei:title)[1], $lang))
     else if (exists($doc/root()/mei:work)) then
         (eutil:getLocalizedTitle($doc/root()/mei:work, $lang))

--- a/add/data/xql/getLinkTarget.xql
+++ b/add/data/xql/getLinkTarget.xql
@@ -158,7 +158,7 @@ declare function local:getWindowTitle($doc as node()+, $type as xs:string) as xs
     
     (: Work :)
     if (exists($doc//mei:mei) and exists($doc//(mei:workDesc|mei:workList)/mei:work) and not(exists($doc//mei:perfMedium))) then
-        (eutil:getLocalizedTitle(($doc//mei:work)[1]/mei:titleStmt[1], $lang))
+        (eutil:getLocalizedTitle((($doc//mei:work)[1]//mei:title)[1], $lang))
     else if (exists($doc/root()/mei:work)) then
         (eutil:getLocalizedTitle($doc/root()/mei:work, $lang))
     

--- a/add/data/xql/getLinkTarget.xql
+++ b/add/data/xql/getLinkTarget.xql
@@ -158,7 +158,9 @@ declare function local:getWindowTitle($doc as node()+, $type as xs:string) as xs
     
     (: Work :)
     if ($type = 'work') then
-        (eutil:getLocalizedTitle((($doc//mei:work)[1]//mei:title)[1], $lang))
+    (: will fail for MEI v3 or older :)
+        eutil:getLocalizedTitle(($doc//mei:work)[1], $lang)
+    
     else if (exists($doc/root()/mei:work)) then
         (eutil:getLocalizedTitle($doc/root()/mei:work, $lang))
     

--- a/add/data/xql/getLinkTarget.xql
+++ b/add/data/xql/getLinkTarget.xql
@@ -192,10 +192,18 @@ declare function local:getWindowTitle($doc as node()+, $type as xs:string) as xs
     (: HTML :)
     else if ($type = 'html') then
         ($doc//head/data(title))
+    
+    else if($type = 'unknown') then
+    
+        let $eventualTitleContainers := ($doc//mei:titleStmt, $doc/tei:titleStmt)
+        let $eventualTitles := (
+            for $et in $eventualTitleContainers return
+                eutil:getLocalizedTitle($eventualTitleContainers[1], $lang),
+            for $t in $doc//*:title return
+                $t => normalize-space()
+        )
         
-    (: MEI fallback if no title is found :)
-    else if (exists($doc//mei:mei) and exists(($doc//mei:titleStmt)[1])) then
-        (eutil:getLocalizedTitle(($doc//mei:titleStmt)[1], $lang))
+        return $eventualTitles[1]
     
     else
         (string('unknown'))

--- a/add/data/xql/getLinkTarget.xql
+++ b/add/data/xql/getLinkTarget.xql
@@ -185,10 +185,6 @@ declare function local:getWindowTitle($doc as node()+, $type as xs:string) as xs
         ($doc//mei:source)[1]//mei:identifier[lower-case(@type) = 'shelfmark'][1]), ' | ')
         => normalize-space())
     
-    (: MEI fallback if no title is found :)
-    else if (exists($doc//mei:mei) and exists(($doc//mei:titleStmt)[1])) then
-        (eutil:getLocalizedTitle(($doc//mei:titleStmt)[1], $lang))
-    
     (: Text :)
     else if ($type = 'text') then
         (eutil:getLocalizedTitle($doc//tei:fileDesc/tei:titleStmt[1], $lang))
@@ -196,6 +192,10 @@ declare function local:getWindowTitle($doc as node()+, $type as xs:string) as xs
     (: HTML :)
     else if ($type = 'html') then
         ($doc//head/data(title))
+        
+    (: MEI fallback if no title is found :)
+    else if (exists($doc//mei:mei) and exists(($doc//mei:titleStmt)[1])) then
+        (eutil:getLocalizedTitle(($doc//mei:titleStmt)[1], $lang))
     
     else
         (string('unknown'))

--- a/add/data/xql/getLinkTarget.xql
+++ b/add/data/xql/getLinkTarget.xql
@@ -161,9 +161,6 @@ declare function local:getWindowTitle($doc as node()+, $type as xs:string) as xs
     (: will fail for MEI v3 or older :)
         eutil:getLocalizedTitle(($doc//mei:work)[1], $lang)
     
-    else if (exists($doc/root()/mei:work)) then
-        (eutil:getLocalizedTitle($doc/root()/mei:work, $lang))
-    
     (: Recording :)
     else if (exists($doc//mei:mei) and exists($doc//mei:recording)) then
         (eutil:getLocalizedTitle($doc//mei:fileDesc/mei:titleStmt[1], $lang))

--- a/add/data/xql/getLinkTarget.xql
+++ b/add/data/xql/getLinkTarget.xql
@@ -37,7 +37,7 @@ declare variable $uri := request:get-parameter('uri', '');
 (:~
  : Returns a view for an edirom object
  :)
-declare function local:getView($type as xs:string, $docUri as xs:string, $doc as node()+) as map(*)? {
+declare function local:getView($type as xs:string, $docUri as xs:string, $doc as document-node()?) as map(*)? {
     let $baseMap := map {
         'type': substring-after($type, '_'),
         'uri':if ($type = ('mei_textView', 'desc_xmlView')) then
@@ -124,7 +124,7 @@ declare function local:getView($type as xs:string, $docUri as xs:string, $doc as
 (:~
  : Returns the views for an edirom object
  :)
-declare function local:getViews($type as xs:string, $docUri as xs:string, $doc as node()+) as map(*)* {
+declare function local:getViews($type as xs:string, $docUri as xs:string, $doc as document-node()?) as map(*)* {
     
     let $views := (
         (:'desc_summaryView',:)
@@ -154,7 +154,7 @@ declare function local:getViews($type as xs:string, $docUri as xs:string, $doc a
 (:~
  : Returns the window title for an edirom-object
  :)
-declare function local:getWindowTitle($doc as node(), $type as xs:string) as xs:string {
+declare function local:getWindowTitle($doc as document-node()?, $type as xs:string) as xs:string {
     
     (: Work :)
     if ($type = 'work') then

--- a/add/data/xql/getLinkTarget.xql
+++ b/add/data/xql/getLinkTarget.xql
@@ -170,7 +170,7 @@ declare function local:getWindowTitle($doc as node()+, $type as xs:string) as xs
             eutil:getLocalizedTitle($workTitleContainer, $lang)
     
     (: Recording :)
-    else if (exists($doc//mei:mei) and exists($doc//mei:recording)) then
+    else if ($type = 'recording') then
         (eutil:getLocalizedTitle($doc//mei:fileDesc/mei:titleStmt[1], $lang))
     
     (: Source / Score :)
@@ -188,7 +188,7 @@ declare function local:getWindowTitle($doc as node()+, $type as xs:string) as xs
         (eutil:getLocalizedTitle(($doc//mei:titleStmt)[1], $lang))
     
     (: Text :)
-    else if (exists($doc/tei:TEI)) then
+    else if ($type = 'text') then
         (eutil:getLocalizedTitle($doc//tei:fileDesc/tei:titleStmt[1], $lang))
     
     (: HTML :)


### PR DESCRIPTION
## Description, Context and related Issue

Remove `mei:titleStmt` when determining the title of the work because in MEI 5 `mei:title` is a direct child of `mei:work`
Closes #337 

## How Has This Been Tested?

With a BAZ-GA MEI 5 work.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Overview
<!--- Go over all the following points, and DELETE options that are not relevant. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online/blob/develop/CONTRIBUTING.md) document.
- I have added tests to cover my changes at [testing](https://github.com/Edirom/Edirom-Online/tree/develop/testing)

- All new and existing tests passed.
--> will know when the PR has run its tests ;-)
