### PR TITLE
fix/cookie-lang-prefs: add error handling and default return

### DIFF
--- a/app/controller/LanguageController.js
+++ b/app/controller/LanguageController.js
@@ -77,9 +77,16 @@ Ext.define('EdiromOnline.controller.LanguageController', {
     },
     
     getLanguage: function() {
-        if(window.getCookie('edirom-language') !== '')
-            return window.getCookie('edirom-language');
-        
-        return getPreference('application_language');
+        /* since removing the cookie, this throws an error because 'application_language' is called before it is defined.
+        * see issue #504
+        * this is a quick fix, language / preferences handling needs some rework
+        */ 
+        try {
+            return getPreference('application_language');
+        }
+        catch (err) {
+            console.log('"application_language" not found, using "en" as default.\n');
+            return 'en'
+        }
     }
 });


### PR DESCRIPTION
## Description, Context and related Issue
Edirom Online failed if no cookie 'edirom-language' was set because pref 'application_language' was called before preferences were set. this commit is a quick fix, which returns default lang 'en' if 'application_language' could not be found.
Refs #504 

## How Has This Been Tested?
tested with current develop of Edirom Online, open-faust dataset and baumann kantate dataset.

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Overview
- I have updated the inline documentation accordingly.
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online/blob/develop/CONTRIBUTING.md) document.
