### PR TITLE
fix/part-names-key: fix translation of part-names if they are not in …

### DIFF
--- a/add/data/xqm/eutil.xqm
+++ b/add/data/xqm/eutil.xqm
@@ -266,17 +266,11 @@ declare function eutil:getLanguageString($key as xs:string, $values as xs:string
     let $base := system:get-module-load-path()
     let $file := eutil:getDoc(concat($base, '/../locale/edirom-lang-', $lang, '.xml'))
     
-    let $string := 
-        if($file//entry[@key = $key]) 
-        then (
-            $file//entry[@key = $key]/string(@value)
-        ) else (
-            'noValueFound'
-        )  
+    let $string := $file//entry[@key = $key]/string(@value)
     let $string := functx:replace-multi($string, for $i in (0 to (count($values) - 1)) return concat('\{',$i,'\}'), $values)
 
     return
-        $string
+        if($string) then $string else 'noValueFound'
 
 };
 

--- a/add/data/xqm/eutil.xqm
+++ b/add/data/xqm/eutil.xqm
@@ -224,7 +224,7 @@ declare function eutil:getPartLabel($measureOrPerfRes as node(), $type as xs:str
     let $dictKey := 'perfMedium.perfRes.' || functx:substring-before-if-contains($perfResLabel,'.')
 
     let $label :=
-        if(eutil:getLanguageString($dictKey, (), $lang)) then
+        if(eutil:getLanguageString($dictKey, (), $lang) != 'noValueFound') then
             (eutil:getLanguageString($dictKey, (), $lang))
         else
             ($perfResLabel)
@@ -266,7 +266,13 @@ declare function eutil:getLanguageString($key as xs:string, $values as xs:string
     let $base := system:get-module-load-path()
     let $file := eutil:getDoc(concat($base, '/../locale/edirom-lang-', $lang, '.xml'))
     
-    let $string := $file//entry[@key = $key]/string(@value)
+    let $string := 
+        if($file//entry[@key = $key]) 
+        then (
+            $file//entry[@key = $key]/string(@value)
+        ) else (
+            'noValueFound'
+        )  
     let $string := functx:replace-multi($string, for $i in (0 to (count($values) - 1)) return concat('\{',$i,'\}'), $values)
 
     return


### PR DESCRIPTION
## Description, Context and related Issue
solve the problem that getParts.xql throws an error if the part names could not be found in lang keys.

Refs #502 
(Refs #302 )

## How Has This Been Tested?
tested with open-faust A3 (with parts), A2 (without parts)

## Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Improvement

## Overview
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online/blob/develop/CONTRIBUTING.md) document.