### PR TITLE
build: separate copying of help images from copy that applies token r…

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -45,6 +45,7 @@ Ext.ClassManager.addNameAlternateMappings({
   "EdiromOnline.controller.window.SummaryView": [],
   "EdiromOnline.controller.window.WindowController": [],
   "EdiromOnline.controller.window.XmlView": [],
+  "EdiromOnline.controller.window.about.AboutWindow": [],
   "EdiromOnline.controller.window.audio.AudioView": [],
   "EdiromOnline.controller.window.concordanceNavigator.ConcordanceNavigator": [],
   "EdiromOnline.controller.window.iFrameView": [],
@@ -78,6 +79,7 @@ Ext.ClassManager.addNameAlternateMappings({
   "EdiromOnline.view.window.View": [],
   "EdiromOnline.view.window.Window": [],
   "EdiromOnline.view.window.XmlView": [],
+  "EdiromOnline.view.window.about.AboutWindow": [],
   "EdiromOnline.view.window.annotationLayouts.AnnotationLayout1": [],
   "EdiromOnline.view.window.annotationLayouts.AnnotationLayout2": [],
   "EdiromOnline.view.window.annotationLayouts.AnnotationLayout3": [],
@@ -956,6 +958,7 @@ Ext.ClassManager.addNameAliasMappings({
   "EdiromOnline.controller.window.SummaryView": [],
   "EdiromOnline.controller.window.WindowController": [],
   "EdiromOnline.controller.window.XmlView": [],
+  "EdiromOnline.controller.window.about.AboutWindow": [],
   "EdiromOnline.controller.window.audio.AudioView": [],
   "EdiromOnline.controller.window.concordanceNavigator.ConcordanceNavigator": [],
   "EdiromOnline.controller.window.iFrameView": [],
@@ -1015,6 +1018,9 @@ Ext.ClassManager.addNameAliasMappings({
   ],
   "EdiromOnline.view.window.XmlView": [
     "widget.xmlView"
+  ],
+  "EdiromOnline.view.window.about.AboutWindow": [
+    "widget.aboutWindow"
   ],
   "EdiromOnline.view.window.annotationLayouts.AnnotationLayout1": [],
   "EdiromOnline.view.window.annotationLayouts.AnnotationLayout2": [],

--- a/build.xml
+++ b/build.xml
@@ -32,6 +32,11 @@
                 <include name="data/xslt/tei/Stylesheets/common/"/>
                 <include name="data/xslt/tei/Stylesheets/VERSION"/>
                 <include name="help/**"/>
+                <exclude name="help/images/">
+                    <!-- exclude help images here because the below filterset
+                         would alter their contents and render them unreadable.
+                         Will be copied in anoter copy statement without filterset. -->
+                </exclude>
                 <include name="index/**"/>
             </fileset>
             <fileset dir="${basedir}">
@@ -43,6 +48,13 @@
                 <filter token="project.title" value="${project.title}"/>
                 <filter token="repo.target" value="${repo.target}"/>
             </filterset>
+        </copy>
+        <copy todir="${build.dir}" preservelastmodified="true">
+            <!-- copy help images in separate copy statement because above filterset
+                 would modify their contents and render them unreadable -->
+            <fileset dir="${basedir}/add">
+                <include name="help/images/"/>
+            </fileset>
         </copy>
         <copy file="${build.dir}/resources/pix/ViFE-logo-small-144x144-trans.png" tofile="${build.dir}/icon.png" overwrite="true"/>
         <copy file="${basedir}/CITATION.cff" tofile="${build.dir}/resources/CITATION.cff" overwrite="true"/>


### PR DESCRIPTION
## Description, Context and related Issue
Separate the copy of help images form the copy task that does token replacement in order to avoid broken images deployed to the database.

Closes #509 

## How Has This Been Tested?
Yes

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Overview
- I have updated the inline documentation accordingly.
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online/blob/develop/CONTRIBUTING.md) document.
- All new and existing tests passed.
