### PR TITLE
update getLanguageString functions

### DIFF
--- a/add/data/xqm/eutil.xqm
+++ b/add/data/xqm/eutil.xqm
@@ -244,10 +244,10 @@ declare function eutil:getPartLabel($measureOrPerfRes as node(), $type as xs:str
  : Returns a language specific string
  :
  : @param $key The key to search for
- : @param $values The values to include into the string
- : @return The string
+ : @param $values The values to replace the placeholders with (from the language string)
+ : @return The looked up language string from a language file
  :)
-declare function eutil:getLanguageString($key as xs:string, $values as xs:string*) as xs:string {
+declare function eutil:getLanguageString($key as xs:string, $values as xs:string*) as xs:string? {
 
     eutil:getLanguageString($key, $values, eutil:getLanguage(''))
 
@@ -255,23 +255,57 @@ declare function eutil:getLanguageString($key as xs:string, $values as xs:string
 
 (:~
  : Returns a language specific string from the locale/edirom-lang files
+ : NB, the project specific language dictionaries are not being queried here.
+ : Please use the four-arity version for this!
  :
  : @param $key The key to search for
- : @param $values The values to include into the string
- : @param $lang The language
- : @return The string
+ : @param $values The values to replace the placeholders with (from the language string)
+ : @param $lang The language code (e.g. "de" or "en")
+ : @return The looked up language string from a language file
  :)
-declare function eutil:getLanguageString($key as xs:string, $values as xs:string*, $lang as xs:string) as xs:string {
+declare function eutil:getLanguageString($key as xs:string, $values as xs:string*, $lang as xs:string) as xs:string? {
 
-    let $base := system:get-module-load-path()
-    let $file := eutil:getDoc(concat($base, '/../locale/edirom-lang-', $lang, '.xml'))
+    let $file := eutil:getDoc(concat('../locale/edirom-lang-', $lang, '.xml'))
     
-    let $string := $file//entry[@key = $key]/string(@value)
-    let $string := functx:replace-multi($string, for $i in (0 to (count($values) - 1)) return concat('\{',$i,'\}'), $values)
+    let $langString := $file//entry[@key = $key]/string(@value)
 
     return
-        $string
+        if($langString) 
+        (: replace placeholders in the language string with values provided to the function as parameter :)
+        then functx:replace-multi($langString, for $i in (0 to (count($values) - 1)) return concat('\{',$i,'\}'), $values)
+        else util:log('error', concat('Failed to find the key `', $key, '` in the Edirom default language file'))
 
+};
+
+(:~
+ : Returns a language specific string from the locale/edirom-lang files or project specific language files.
+ : The latter takes precedence.
+ :
+ : @param $edition The URI of the Edition's document to process
+ : @param $key The key to search for
+ : @param $values The values to replace the placeholders with (from the language string) 
+ : @param $lang The language code (e.g. "de" or "en")
+ : @return The looked up language string from a language file
+ :)
+declare function eutil:getLanguageString($edition as xs:string, $key as xs:string, $values as xs:string*, $lang as xs:string) as xs:string? {
+
+    (: Try to load a custom language file :)
+    let $langFileCustom := 
+        try { doc(edition:getLanguageFileURI($edition, $lang)) }
+        catch * { util:log-system-out('Failed to load the custom language file for edition "' || $edition || '"') }
+    
+    let $langString :=
+        (: If there is a value for the key in the custom language file :)
+        if($langFileCustom//entry/@key = $key) then
+            $langFileCustom//entry[@key = $key]/@value => string()
+        (: If not, take the value for the key in the default language file :)
+        else
+            eutil:getDoc(concat('../locale/edirom-lang-', $lang, '.xml'))//entry[@key = $key]/@value => string()
+    return
+        if($langString) 
+        (: replace placeholders in the language string with values provided to the function as parameter :)
+        then functx:replace-multi($langString, for $i in (0 to (count($values) - 1)) return concat('\{',$i,'\}'), $values)
+        else util:log('error', concat('Failed to find the key `', $key, '` in any language file'))
 };
 
 (:~

--- a/testing/XQSuite/data/edition.xml
+++ b/testing/XQSuite/data/edition.xml
@@ -1,0 +1,8 @@
+<?xml-model href="https://raw.githubusercontent.com/Edirom/edirom-edition-schema/develop/edirom-edition/v1.3.0/edirom.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<edition xmlns="http://www.edirom.de/ns/1.3" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://www.edirom.de/ns/1.3 https://raw.githubusercontent.com/Edirom/edirom-edition-schema/develop/edirom-edition/v1.3.0/edirom_edition.xsd" xml:id="edirom_edition_example">
+    <editionName>Edirom Edition Example</editionName>
+    <languages>
+        <language xml:lang="de" xlink:href="xmldb:exist:///db/apps/Edirom-Online/testing/XQSuite/data/language-de.xml"/>
+        <language xml:lang="it" xlink:href="xmldb:exist:///db/apps/Edirom-Online/testing/XQSuite/data/language-it.xml"/>
+    </languages>
+</edition>

--- a/testing/XQSuite/data/language-de.xml
+++ b/testing/XQSuite/data/language-de.xml
@@ -1,0 +1,8 @@
+<langFile>
+    <lang>de</lang>
+    <version>1.0</version>
+    <entries>
+        <entry key="global_cancel" value="Test-Abbrechen"/>
+        <entry key="view.desktop.TaskBar_Desktop" value="Test-Desktop {0}"/>
+    </entries>
+</langFile>

--- a/testing/XQSuite/data/language-it.xml
+++ b/testing/XQSuite/data/language-it.xml
@@ -1,0 +1,8 @@
+<langFile>
+    <lang>it</lang>
+    <version>1.0</version>
+    <entries>
+        <entry key="global_cancel" value="Test-it-Abbrechen"/>
+        <entry key="view.desktop.TaskBar_Desktop" value="Test-it-Desktop {0}"/>
+    </entries>
+</langFile>

--- a/testing/XQSuite/eutil-tests.xqm
+++ b/testing/XQSuite/eutil-tests.xqm
@@ -49,3 +49,75 @@ declare
     function eut:test-getDoc($uri as xs:string?) as document-node()? {
         eutil:getDoc($uri)
 };
+
+declare 
+    (: Test empty replacements with non-existing key :)
+    %test:arg("key", "foo1g4#")
+    %test:arg("values") 
+    %test:arg("lang", "de") %test:assertEmpty
+    (: Test empty replacements with existing key :)
+    %test:arg("key", "view.desktop.Desktop_Maximize")
+    %test:arg("values") 
+    %test:arg("lang", "de") %test:assertEquals("Maximieren")
+    (: Test empty replacements with existing key in another language :)
+    %test:arg("key", "view.desktop.Desktop_Maximize")
+    %test:arg("values") 
+    %test:arg("lang", "en") %test:assertEquals("Maximize")
+    (: Test replacements with existing key :)
+    %test:args("view.desktop.TaskBar_Desktop", "5", "de") %test:assertEquals("Desktop 5")
+    (: Test replacements with existing key in another language :)
+    %test:args("view.desktop.TaskBar_Desktop", "foo", "en") %test:assertEquals("Desktop foo")
+    (: Test replacements with existing key without placeholders :)
+    %test:args("view.desktop.Desktop_Maximize", "foo", "de") %test:assertEquals("Maximieren")
+    (: Test replacements with existing key and non-existing language :)
+    %test:args("view.desktop.Desktop_Maximize", "foo", "foo1g4#lang") %test:assertEmpty
+    (: Test empty replacements with non-existing key and non-existing language :)
+    %test:arg("key", "foo1g4#")
+    %test:arg("values") 
+    %test:arg("lang", "foo1g4#lang") %test:assertEmpty
+    function eut:test-getLanguageString-3-arity($key as xs:string, $values as xs:string*, $lang as xs:string) as xs:string? {
+        eutil:getLanguageString($key, $values, $lang)
+};
+
+declare 
+    (: Test empty replacements with non-existing key :)
+    %test:arg("edition", "edirom_edition_example")
+    %test:arg("key", "foo1g4#")
+    %test:arg("values") 
+    %test:arg("lang", "de") %test:assertEmpty
+    (: Test empty replacements with existing key :)
+    %test:arg("edition", "edirom_edition_example")
+    %test:arg("key", "global_cancel")
+    %test:arg("values") 
+    %test:arg("lang", "de") %test:assertEquals("Test-Abbrechen")
+    (: Test empty replacements with existing key in another language :)
+    %test:arg("edition", "edirom_edition_example")
+    %test:arg("key", "global_cancel")
+    %test:arg("values") 
+    %test:arg("lang", "it") %test:assertEquals("Test-it-Abbrechen")
+    (: Test replacements with existing key :)
+    %test:args("edirom_edition_example", "view.desktop.TaskBar_Desktop", "5", "de") %test:assertEquals("Test-Desktop 5")
+    (: Test replacements with existing key in another language :)
+    %test:args("edirom_edition_example", "view.desktop.TaskBar_Desktop", "foo", "it") %test:assertEquals("Test-it-Desktop foo")
+    (: Test replacements with existing key without placeholders :)
+    %test:args("edirom_edition_example", "global_cancel", "foo", "de") %test:assertEquals("Test-Abbrechen")
+    (: Test replacements with existing key and non-existing language :)
+    %test:args("edirom_edition_example", "global_cancel", "foo", "foo1g4#lang") %test:assertEmpty
+    (: Test empty replacements with non-existing key and non-existing language :)
+    %test:arg("edition", "edirom_edition_example")
+    %test:arg("key", "foo1g4#")
+    %test:arg("values") 
+    %test:arg("lang", "foo1g4#lang") %test:assertEmpty
+    (: Test empty replacements with existing key from default language file :)
+    %test:arg("edition", "edirom_edition_example")
+    %test:arg("key", "view.desktop.Desktop_Maximize")
+    %test:arg("values") 
+    %test:arg("lang", "de") %test:assertEquals("Maximieren")
+    (: Test empty replacements with non-existing editionID – with existing key from default language file :)
+    %test:arg("edition", "foobar4#_edition")
+    %test:arg("key", "view.desktop.Desktop_Maximize")
+    %test:arg("values") 
+    %test:arg("lang", "de") %test:assertEquals("Maximieren")
+    function eut:test-getLanguageString-4-arity($edition as xs:string, $key as xs:string, $values as xs:string*, $lang as xs:string) as xs:string? {
+        eutil:getLanguageString($edition, $key, $values, $lang)
+};


### PR DESCRIPTION
and add tests. This will avoid function errors due to returning empty sequence instead of strings.

In fact, this is a replacement for #511 which our Kleingruppe considered only a workaround.
Refs #502

## How Has This Been Tested?
By adding tests

## Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Improvement
- Refactoring

## Overview
- I have updated the inline documentation accordingly.
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online/blob/develop/CONTRIBUTING.md) document.
- I have added tests to cover my changes at [testing](https://github.com/Edirom/Edirom-Online/tree/develop/testing)
- All new and existing tests passed.
