### PR TITLE
Rework get and find editions

### DIFF
--- a/add/data/xql/getEditionURI.xql
+++ b/add/data/xql/getEditionURI.xql
@@ -12,6 +12,7 @@ xquery version "3.1";
 (: IMPORTS ================================================================= :)
 
 import module namespace edition = "http://www.edirom.de/xquery/edition" at "../xqm/edition.xqm";
+import module namespace eutil = "http://www.edirom.de/xquery/eutil" at "../xqm/eutil.xqm";
 
 (: NAMESPACE DECLARATIONS ================================================== :)
 
@@ -27,7 +28,6 @@ declare option output:method "text";
 
 let $uri := request:get-parameter('uri', '')
 return
-    if (doc-available($uri)) then
-        ($uri)
-    else
-        (edition:findEdition($uri))
+    if (edition:getEditionURI($uri))
+    then edition:getEditionURI($uri)
+    else edition:findEditionUris()[1]

--- a/add/data/xqm/edition.xqm
+++ b/add/data/xqm/edition.xqm
@@ -50,11 +50,14 @@ declare function edition:details($uri as xs:string) as map(*) {
  :
  : @return The list of URIs
  :)
-declare function edition:getUris() as xs:string* {
+declare function edition:findEditionUris() as xs:string* {
     
-    for $edition in collection('/db/apps')//edirom:edition
+    for $edition in collection('/db/apps')/edirom:edition
+    let $document-uri := document-uri($edition/root())
+    (: exclude editions found within the testing collection :)
+    where not(contains($document-uri, 'testing/XQSuite/data'))
     return
-        'xmldb:exist://' || document-uri($edition/root())
+        'xmldb:exist://' || $document-uri
 };
 
 (:~
@@ -77,15 +80,7 @@ declare function edition:getWorkUris($uri as xs:string) as xs:string* {
  :)
 declare function edition:getLanguageFileURI($uri as xs:string, $lang as xs:string) as xs:string {
 
-    let $doc := (
-        if(doc-available($uri)) then
-            doc($uri)
-        else
-            if(edition:findEdition($uri)) then
-                doc(edition:findEdition($uri))
-            else
-                ()
-    )
+    let $doc := edition:getEditionURI($uri) => eutil:getDoc()
     return
         if ($doc//edirom:language[@xml:lang eq $lang]/@xlink:href => string() != "") then
             $doc//edirom:language[@xml:lang eq $lang]/@xlink:href => string()
@@ -139,27 +134,27 @@ declare function edition:getPreferencesURI($uri as xs:string?) as xs:string {
 };
 
 (:~
- : Returns the URI of the edition specified by the submitted $editionID parameter.
- : If $editionID is the empty string, returns the URI of the first edition found in '/db/apps'.
- : If the submitted $editionID already qualifies to read a document, return $editionID unaltered.
+ : Returns the URI of the edition specified by the submitted $editionIDorPath parameter.
  :
- : @param $editionID The '@xml:id' of the edirom:edition document to process
+ : @param $editionIDorPath The '@xml:id' of or the database path to the edirom:edition document to process
  : @return The URI of the Edition file
  :)
-declare function edition:findEdition($editionID as xs:string?) as xs:string? {
-    
-    if(not($editionID) or $editionID eq '') then(
-        let $edition := (collection('/db/apps')//edirom:edition)[1]
-        return 'xmldb:exist://' || document-uri($edition/root())
-    
-    ) else if(doc-available($editionID)) (:already a qualified URI :) then
-        $editionID
-    
-    else (
-        let $edition := collection('/db/apps')//edirom:edition/id($editionID)
-        return
-            'xmldb:exist://' || document-uri($edition/root())
-        )
+declare function edition:getEditionURI($editionIDorPath as xs:string?) as xs:string? {
+    (: $editionID is the empty sequence or the empty string :)
+    if(not($editionIDorPath))
+    then ()
+
+    (: $editionID is a resolvable file path with an edirom:edition root element :)
+    else if(doc-available($editionIDorPath))
+    then doc($editionIDorPath)/edirom:edition ! concat('xmldb:exist://', document-uri(./root()))
+
+    (: $editionID is a resolvable xml:id that points at an edirom:edition :)
+    (: since there are potentially multiple documents with the same xml:id we fall back to returning only the first one :)
+    else if (collection('/db/apps')/id($editionIDorPath)/self::edirom:edition)
+    then (collection('/db/apps')/id($editionIDorPath)/self::edirom:edition)[1] ! concat('xmldb:exist://', document-uri(./root()))
+
+    (: for everything else the empty sequence will be returned :)
+    else ()
 };
 
 (:~

--- a/add/data/xqm/eutil.xqm
+++ b/add/data/xqm/eutil.xqm
@@ -343,8 +343,8 @@ declare function eutil:getLanguage($edition as xs:string?) as xs:string {
     
     if (request:get-parameter("lang", "") != "") then
         request:get-parameter("lang", "")
-    else if(eutil:getPreference('application_language', edition:findEdition($edition))) then
-        eutil:getPreference('application_language', edition:findEdition($edition))
+    else if(eutil:getPreference('application_language', edition:getEditionURI($edition))) then
+        eutil:getPreference('application_language', edition:getEditionURI($edition))
     else    
         'de'
 };

--- a/testing/XQSuite/edition-tests.xqm
+++ b/testing/XQSuite/edition-tests.xqm
@@ -1,0 +1,21 @@
+xquery version "3.1";
+
+module namespace edt = "http://www.edirom.de/xquery/xqsuite/edition-tests";
+
+import module namespace edition = "http://www.edirom.de/xquery/edition" at "xmldb:exist:///db/apps/Edirom-Online/data/xqm/edition.xqm";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+
+declare
+    (: check xml:id :)
+    %test:args("edirom_edition_example")
+    %test:assertEquals("xmldb:exist:///db/apps/Edirom-Online/testing/XQSuite/data/edition.xml")
+    (: check database path :)
+    %test:args("/db/apps/Edirom-Online/testing/XQSuite/data/edition.xml")
+    %test:assertEquals("xmldb:exist:///db/apps/Edirom-Online/testing/XQSuite/data/edition.xml")
+    (: check empty sequence :)
+    %test:arg("editionIDorPath")       %test:assertEmpty
+    function edt:test-getEditionURI($editionIDorPath as xs:string?) as xs:string?  {
+        edition:getEditionURI($editionIDorPath)
+};

--- a/testing/XQSuite/run-unit-tests.xq
+++ b/testing/XQSuite/run-unit-tests.xq
@@ -9,8 +9,10 @@ xquery version "3.1";
 import module namespace test="http://exist-db.org/xquery/xqsuite" at "resource:org/exist/xquery/lib/xqsuite/xqsuite.xql";
  
 import module namespace eut="http://www.edirom.de/xquery/xqsuite/eutil-tests" at "eutil-tests.xqm";
+import module namespace edt="http://www.edirom.de/xquery/xqsuite/edition-tests" at "edition-tests.xqm";
 
 (: the test:suite() function will run all the test-annotated functions in the module whose namespace URI you provide :)
 test:suite((
-    util:list-functions("http://www.edirom.de/xquery/xqsuite/eutil-tests")
+    util:list-functions("http://www.edirom.de/xquery/xqsuite/eutil-tests"),
+    util:list-functions("http://www.edirom.de/xquery/xqsuite/edition-tests")
 ))


### PR DESCRIPTION
## Description, Context and related Issue
When adding an edition file as test data to the testing/XQsuite/data collection the Edirom would automatically pick up this "edition". This PR rewrites the functions for finding (all) editions from the database (formerly `edition:getUris#0`, now `edition:findEditionUris#0`) and the function for retrieving (just) one edition by its ID or database path (formerly `edition:findEdition#1`, now `edition:getEditionURI#1`). 

The notable difference of `edition:getEditionURI#1` is that it now will return the empty sequence if no resolvable edition ID or path is provided. It will not magically search the whole database. If this is intended, you'll need to combine this with `edition:findEditionUris#0`. See `index.xql` where this change got necessary.


## How Has This Been Tested?
Tested locally with the clarinet quintet and the Pintos data.

## Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to change)
- Improvement
- Refactoring

## Overview
- I have updated the inline documentation accordingly.
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online/blob/develop/CONTRIBUTING.md) document.
- I have added tests to cover my changes at [testing](https://github.com/Edirom/Edirom-Online/tree/develop/testing)
- All new and existing tests passed.
