### PR TITLE
Update source module and fix `source:getSiglum#1`

### DIFF
--- a/add/data/xqm/source.xqm
+++ b/add/data/xqm/source.xqm
@@ -135,11 +135,8 @@ declare function source:getSiglum($source as xs:string) as xs:string? {
 
     let $doc := doc($source)
     let $elems := $doc//mei:*[@type eq 'siglum']
-    let $siglum :=
-        if(exists($elems)) then
-            ($elems[1]//text())
-        else
-            ()
-
-    return $siglum
+    return
+        if(exists($elems))
+        then $elems[1] => normalize-space()
+        else ()
 };

--- a/add/data/xqm/source.xqm
+++ b/add/data/xqm/source.xqm
@@ -70,7 +70,7 @@ declare function source:getLabels($sources as xs:string*, $edition as xs:string)
  :)
 declare function source:getLabel($source as xs:string, $edition as xs:string) as xs:string {
 
-    let $sourceDoc := doc($source)
+    let $sourceDoc := eutil:getDoc($source)
     let $language := eutil:getLanguage($edition)
 
     let $label :=
@@ -85,7 +85,7 @@ declare function source:getLabel($source as xs:string, $edition as xs:string) as
         if($label) then
             ($label)
         else
-            (doc($source)//mei:meiHead/mei:fileDesc/mei:titleStmt/mei:title[not(@xml:lang) or @xml:lang = $language])
+            ($sourceDoc//mei:meiHead/mei:fileDesc/mei:titleStmt/mei:title[not(@xml:lang) or @xml:lang = $language])
 
     let $label :=
         if($label) then
@@ -112,7 +112,7 @@ declare function source:getSigla($sources as xs:string*) as xs:string {
 };
 
 (:~
- : Returns an array of source sigla
+ : Returns a sequence of source sigla
  :
  : @param $sources The URIs of the Sources' documents to process
  : @return The sigla
@@ -133,7 +133,7 @@ declare function source:getSiglaAsArray($sources as xs:string*) as xs:string* {
  :)
 declare function source:getSiglum($source as xs:string) as xs:string? {
 
-    let $doc := doc($source)
+    let $doc := eutil:getDoc($source)
     let $elems := $doc//mei:*[@type eq 'siglum']
     return
         if(exists($elems))


### PR DESCRIPTION
## Description, Context and related Issue

in the Pintos there's a siglum encoded like
```xml
<add xml:id="x38284ce9-f2be-4ca6-a8cb-227d85357ae1" place="rightmar" type="siglum">
    <rend xml:id="x9bbd3666-54ac-4287-b7f7-1d19347c7e14" color="red">Classe III.
        <lb xml:id="x7e7c09da-9ed9-4ed4-9339-75a18868a860"/>Band
        <lb xml:id="xd18991b0-bc11-447b-881a-b732d8f3b3c4"/>V. No. <rend xml:id="x4904459c-a4c4-40a9-beb5-d9f3c21ddeca" rend="underline">80</rend>.</rend>
</add>
```
which features multiple text nodes causing the original function `source:getSiglum#1` to fail.

This PR fixes the function `source:getSiglum#1` and applies some minor updates to the rest of the module.


## How Has This Been Tested?

With the Pintos data

## Types of changes

- Bug fix (non-breaking change which fixes an issue)
- Improvement
- Refactoring

## Overview
- I have updated the inline documentation accordingly.
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online/blob/develop/CONTRIBUTING.md) document.
- All new and existing tests passed.
