### PR TITLE
ensure to return a string

### DIFF
--- a/add/data/xql/getLinkTarget.xql
+++ b/add/data/xql/getLinkTarget.xql
@@ -206,8 +206,8 @@ declare function local:getWindowTitle($doc as document-node()?, $type as xs:stri
             for $t in $doc//*:title return
                 $t => normalize-space()
         )
-        
-        return $eventualTitles[1]
+        (: ensure to return a string when $eventualTitles is the empty sequence :)
+        return $eventualTitles[1] => string()
     
     else
         ('[No title found!]')


### PR DESCRIPTION
ensure to return a string when $eventualTitles is the empty sequence.
The error surfaced in the current Open-Faust data where there is a link from the navigator to a non-existent file.


## How Has This Been Tested?

Open-Faust data

## Types of changes

- Bug fix (non-breaking change which fixes an issue)
- Improvement


## Overview
- I have updated the inline documentation accordingly.
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online/blob/develop/CONTRIBUTING.md) document.
- All new and existing tests passed.
