### PR TITLE
badge and link for global DOI (redirects to latest)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![FAIR checklist badge](https://fairsoftwarechecklist.net/badge.svg)](https://fairsoftwarechecklist.net/v0.2?f=31&a=32113&i=32300&r=133) 
 [![OpenSSF Best Practices](https://bestpractices.coreinfrastructure.org/projects/9746/badge)](https://bestpractices.coreinfrastructure.org/projects//9746)
 [![fair-software.eu](https://img.shields.io/badge/fair--software.eu-%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F-green)](https://fair-software.eu)
-[![DOI](https://zenodo.org/badge/5966814.svg)](https://zenodo.org/badge/latestdoi/5966814)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5347861.svg)](https://doi.org/10.5281/zenodo.5347861)
 
 </div>
 


### PR DESCRIPTION
## Description, Context and related Issue
<!--- Please describe your changes. Why is this change required? What problem does it solve? -->
DOI badge was broken, and has been fixed. Badge and link are for "global" DOI for Edirom Online now

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Refs #525

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
Having a look at GitHub repo on branch [fix/525-zenodo-badge](https://github.com/Edirom/Edirom-Online/tree/fix/525-zenodo-badge)

## Types of changes
<!--- What types of changes does your code introduce? Please DELETE options that are not relevant. -->
- Bug fix (non-breaking change which fixes an issue)

## Overview
<!--- Go over all the following points, and DELETE options that are not relevant. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- I have updated the inline documentation accordingly.
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online/blob/develop/CONTRIBUTING.md) document.
- All new and existing tests passed.
