### PR TITLE
fix getPreference function

### DIFF
--- a/app/controller/PreferenceController.js
+++ b/app/controller/PreferenceController.js
@@ -72,7 +72,11 @@ Ext.define('EdiromOnline.controller.PreferenceController', {
 	        var lang = me.getURLParameter("lang");
 	        if(lang) {
 		        return lang;
-	        } else {
+	        }
+            else if(me.preferences[key]) {
+                return me.preferences[key];
+            }
+            else {
 		        return "en";
 	        }
         }


### PR DESCRIPTION
the getPreference would only check the URL parameter and not the actual preferences for the key "application_language". This resulted in an always-English frontend independent of the preferences set in the prefs file.

The issue was reported by @obertsalome and can be reproduced with the current Pintos data by simply starting the Edirom without any URL parameter. This will show the frontend GUI elements in English although the "application_language" is set to "de".


## Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Improvement

## Overview
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online/blob/develop/CONTRIBUTING.md) document.
- All new and existing tests passed.
