### PR TITLE
Fix edition details

### DIFF
--- a/add/data/xqm/edition.xqm
+++ b/add/data/xqm/edition.xqm
@@ -41,7 +41,7 @@ declare function edition:details($uri as xs:string) as map(*) {
         map {
             "id": $edition/string(@xml:id),
             "doc": $uri,
-            "name": $edition/edirom:editionName
+            "name": $edition/edirom:editionName => fn:normalize-space()
         }
 };
 

--- a/add/data/xqm/edition.xqm
+++ b/add/data/xqm/edition.xqm
@@ -159,14 +159,14 @@ declare function edition:getEditionURI($editionIDorPath as xs:string?) as xs:str
 
 (:~
  : Returns the name of the edition specified by $uri
+ : This is a shortcut function for `edition:details($uri)?name`
+ : and might get deprecated in the future.
  :
  : @param $uri The URI of the Edition's document to process
  : @return the text contents of edirom:edition/edirom:editionName
  :)
 declare function edition:getName($uri as xs:string) as xs:string {
-
-    doc($uri)/edirom:edition/edirom:editionName => fn:normalize-space()
-
+    edition:details($uri)?name
 };
 
 (:~


### PR DESCRIPTION
## Description, Context and related Issue

The function `edition:details($uri)?name` would return an element node instead of a string value, thus the endpoint `getEdition.xql` returns e.g. `"name" : "<editionName xmlns=\"http://www.edirom.de/ns/1.3\">Pintos-Edirom von Salome Obert</editionName>"` (among other properties).

This PR fixes this to return only the string value and refactors another function to not duplicate code.

## Steps to reproduce 

Check the Ajax request to `getEdition.xql` which is loaded at every star of the Edirom:  
<img width="1512" alt="Bildschirmfoto 2025-01-14 um 18 41 29" src="https://github.com/user-attachments/assets/ea67eac0-4d52-4f54-b5a2-0bd13ada1e97" />
(The screenshot already displays the fixed version)

## How Has This Been Tested?
With the Pintos data

## Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Improvement
- Refactoring

## Overview
- I have updated the inline documentation accordingly.
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online/blob/develop/CONTRIBUTING.md) document.
- All new and existing tests passed.
