### PR TITLE
fix some annotations-in-text issues

### DIFF
--- a/add/data/xql/getAnnotationsInText.xql
+++ b/add/data/xql/getAnnotationsInText.xql
@@ -49,13 +49,12 @@ declare function local:getAnnotations($uriSharp as xs:string, $annotations as el
         let $plist as array(*) :=
             array {
                 for $p in tokenize($annotation/@plist, '\s+')
+                where starts-with($p, $uriSharp)
                 return
-                    if (starts-with($p, $uriSharp)) then
-                        (concat('{id:"', $id, '__', substring-after($p, $uriSharp), '"}'))
-                    else
-                        ()
+                    map {
+                        'id': concat( $id, '__', substring-after($p, $uriSharp))
+                    }
             }
-        let $plist := string-join($plist, ',')
         return
             map {
                 'id': $id,

--- a/add/data/xqm/teitext.xqm
+++ b/add/data/xqm/teitext.xqm
@@ -28,7 +28,7 @@ declare namespace tei="http://www.tei-c.org/ns/1.0";
  :)
 declare function teitext:isText($uri as xs:string) as xs:boolean {
 
-    exists(doc($uri)/tei:TEI)
+    exists(eutil:getDoc($uri)/tei:TEI)
 
 };
 
@@ -40,8 +40,6 @@ declare function teitext:isText($uri as xs:string) as xs:boolean {
  :)
 declare function teitext:getLabel($uri as xs:string, $edition as xs:string) as xs:string {
 
-    let $language := eutil:getLanguage($edition)
-
-    return doc($uri)//tei:titleStmt/data(tei:title[not(@xml:lang) or @xml:lang = $language])
+    eutil:getLocalizedTitle(eutil:getDoc($uri), eutil:getLanguage($edition))
 
 };


### PR DESCRIPTION
## Description, Context and related Issue

There surfaced two issues when testing with the Open-Faust data which might be connected to #460.
1. JSONification of the `local:getAnnotations` function was not complete. The function returned a map object `plist` as string, causing some Javascript function to fail.
2. `teitext:getLabel#2` would return a sequence of strings (under some circumstances) which was not allowed by the return value of the function signature.

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Refs #460


## Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Improvement
- Refactoring

## Overview
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online/blob/develop/CONTRIBUTING.md) document.
- All new and existing tests passed.
