### PR TITLE
build: switch to sencha-cmd:2.1.0

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ while getopts "d" flag; do
     # set a variable OPTIONS with the remaining input arguments to pass to the build command
     OPTIONS=${@} 
     # run docker
-    docker run --rm -it -v `pwd`:/app --name sencha ghcr.io/bwbohl/sencha-cmd:latest ./build.sh $OPTIONS
+    docker run --rm -it -v `pwd`:/app --name sencha ghcr.io/bwbohl/sencha-cmd:2.1 ./build.sh $OPTIONS
    exit
    ;;   
    \?)

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ while getopts "d" flag; do
     # set a variable OPTIONS with the remaining input arguments to pass to the build command
     OPTIONS=${@} 
     # run docker
-    docker run --rm -it -v `pwd`:/app --name sencha ghcr.io/bwbohl/sencha-cmd:2.1 ./build.sh $OPTIONS
+    docker run --rm -it -v `pwd`:/app --name sencha ghcr.io/bwbohl/sencha-cmd:2.1.0 ./build.sh $OPTIONS
    exit
    ;;   
    \?)


### PR DESCRIPTION
## Description, Context and related Issue
To stabilise the build this PR changes the used tag of ghcr.io/bwbohl/sencha-cmd from `latest` to `2.1`.