### PR TITLE
update documentation to provide default value for exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ Edirom Online is released to the public under the terms of the [GNU GPL v.3] ope
 [CONTRIBUTING]: CONTRIBUTING.md
 [Docker]: https://docs.docker.com/
 [Docker Compose]: https://docs.docker.com/compose/
-[building sample data]: https://github.com/Edirom/EditionExample?tab=readme-ov-file#building
+[building sample data]: https://github.com/Edirom/Edirom-Online/blob/develop/docs/setup.md#build-data-package
 [Edirom mailing list]: https://lists.uni-paderborn.de/mailman/listinfo/edirom-l
 [wiki]: https://github.com/Edirom/Edirom-Online/wiki
 [GitHub Discussions]: https://github.com/Edirom/Edirom-Online/discussions

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -81,12 +81,7 @@ Also at this step we can use a docker image, instead of downloading exist on our
 - once the exist-db is ready, you can open its dashboard in your browser: [`http://localhost:8080/exist/apps/dashboard/index.html`](http://localhost:8080/exist/apps/dashboard/index.html)
 - login to the exist-db via the "Login" button in the top right corner:
     - user: admin
-    - pass: will be random-generated, but printed in the exist-db container output above, it looks like that:
-        ```
-        no admin password provided
-        setting password to Thh3Mj3iUYG2OYpakbslXiTs
-        ``` 
-    - you might also want to save that password, because it wont be shown elsewhere
+    - pass: the default is "changeme" (without "" around the word), you can change the default password in the [dockerfile](https://github.com/Edirom/Edirom-Online/blob/fee20389874de6eb8ab01d133a26d7f17cb11f33/backend/Dockerfile#L72)
 - go to "Package Manager" in the menu on the left and upload the two previously generated xar-packages
     - `Edirom-Online-Backend-1.0.0-2025213-1739.xar` (version and date-string varies)
     - `Edirom-Online-Frontend-1.0.0-2025213-1739.xar` (version and date-string varies)


### PR DESCRIPTION
## Description, Context and related Issue
<!--- Please describe your changes. Why is this change required? What problem does it solve? -->
during teaching at ESS2025 we realized, our students were not able to identify the default password easily after modifying their data packages and tried to upload it to the package manager of exist (this is only possible with a login to the db). In the past, a password was auto-generated locally and had to be stored. after the default password was introduced, this documentation is needed. 

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Closes https://github.com/Edirom/Edirom-Online/issues/586

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
proofread

## Types of changes
<!--- What types of changes does your code introduce? Please DELETE options that are not relevant. -->
- Documentation Update

## Overview
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online/blob/develop/CONTRIBUTING.md) document.
