### PR TITLE
[ftr] configurable ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ The default configuration of Edirom Online starts the backend service on port 80
 export BE_PORT=8081
 
 # set the frontend port
-export BE_PORT=8090
+export FE_PORT=8090
 ```
 
 **Step 5**: Start Edirom Online.

--- a/README.md
+++ b/README.md
@@ -131,7 +131,19 @@ Option (b): By copying one or more edition xar packages to the directory **/back
 
 If you want to you can also dive into the process of [building sample data] yourself, but at this step providing the public location or a copy of a xar file is enough.
 
-**Step 4**: Start Edirom Online.
+**Step 4 (optional)**: Set ports.
+
+The default configuration of Edirom Online starts the backend service on port 8080 and the frontend service on port 8089 of your machine. If you want to make these service run on other ports you can specify these by setting the corresponding environment variables:
+
+```bash
+# set the backend port
+export BE_PORT=8081
+
+# set the frontend port
+export BE_PORT=8090
+```
+
+**Step 5**: Start Edirom Online.
 
 The Edirom Online is started via entering the following command in the command line:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
       args:
         SOURCE: ${FE_REPO:-https://github.com/Edirom/Edirom-Online-Frontend.git}
         BRANCH: ${FE_BRANCH:-v1.0.1}
+        # Backend port for frontend configuration
+        BE_PORT: ${BE_PORT:-8080}
     ports:
       # expose nginx
       - "${FE_PORT:-8089}:80"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
         EDITION: ${EDITION_XAR}
     ports:
       # expose eXist-db
-      - "8080:8080"
+      - "${BE_PORT:-8080}:8080"
   edirom-online-frontend:
     container_name: nginx
     build:
@@ -23,4 +23,4 @@ services:
         BRANCH: ${FE_BRANCH:-v1.0.1}
     ports:
       # expose nginx
-      - "8089:80"
+      - "${FE_PORT:-8089}:80"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -15,6 +15,7 @@ FROM openjdk:8-jre-slim as builder
 ARG ANT_VERSION=1.10.12
 ARG SOURCE=https://github.com/Edirom/Edirom-Online-Frontend.git
 ARG BRANCH=v1.0.1
+ARG BE_PORT
 
 
 # Install wget and unzip and ruby and other dependencies
@@ -59,6 +60,15 @@ WORKDIR /opt/eo-frontend
 
 RUN echo "Cloning from repo $SOURCE" && \
     git clone "$SOURCE" --branch "$BRANCH" --single-branch . && \
+    if [ -n "$BE_PORT" && "$BE_PORT" != "8080" ]; then \
+        echo "Setting backend port" && \
+        if  [ -f "./local.properties" ]; then \
+            sed -i '/^backend\.port=/d' local.properties; \
+            echo "backend.port=$BE_PORT" >> local.properties; \
+        else \
+            echo "backend.port=$BE_PORT" >> local.properties; \
+        fi \
+    fi && \
     echo "Building Frontend XAR..." && \
     ./build.sh
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -61,7 +61,7 @@ WORKDIR /opt/eo-frontend
 RUN echo "Cloning from repo $SOURCE" && \
     git clone "$SOURCE" --branch "$BRANCH" --single-branch . && \
     if [ -n "$BE_PORT" ] && [ "$BE_PORT" != "8080" ]; then \
-        echo "Setting backend port"; \
+        echo "Writing backend.port=$BE_PORT to local.properties…"; \
         if [ -f "./local.properties" ]; then \
             sed -i '/^backend\.port=/d' local.properties; \
             echo "backend.port=$BE_PORT" >> local.properties; \

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -60,9 +60,9 @@ WORKDIR /opt/eo-frontend
 
 RUN echo "Cloning from repo $SOURCE" && \
     git clone "$SOURCE" --branch "$BRANCH" --single-branch . && \
-    if [ -n "$BE_PORT" && "$BE_PORT" != "8080" ]; then \
-        echo "Setting backend port" && \
-        if  [ -f "./local.properties" ]; then \
+    if [ -n "$BE_PORT" ] && [ "$BE_PORT" != "8080" ]; then \
+        echo "Setting backend port"; \
+        if [ -f "./local.properties" ]; then \
             sed -i '/^backend\.port=/d' local.properties; \
             echo "backend.port=$BE_PORT" >> local.properties; \
         else \


### PR DESCRIPTION
## Description, Context and related Issue
<!--- Please describe your changes. Why is this change required? What problem does it solve? -->

- make backend port configurable via `BE_PORT` as build argument, defaulting to previous value `8080`
- make frontend port configurable via `FE_PORT` as build argument, defaulting to previous value `8089`
- pass `$BE_PORT` to frontend build 
- add `BE_PORT` as build argument to frontend/Dockerfile
- handle `BE_PORT` in Dockerfile and if not empty and not 8080 (default) place in local.properties file before building

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
refs #573
refs #581
refs https://github.com/Edirom/Edirom-Online-Frontend/issues/82

> [!WARNING]
> Blocked by:  https://github.com/Edirom/Edirom-Online-Frontend/pull/110

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
Using Edirom Online Docker Compose setup

- [ ] Test with consecutive builds changing ports (especially with changing BE_PORT)

> [!WARNING]
> Test with:  https://github.com/Edirom/Edirom-Online-Frontend/pull/110

## Types of changes
<!--- What types of changes does your code introduce? Please DELETE options that are not relevant. -->
- New feature (non-breaking change which adds functionality)
- Documentation Update
- Improvement

## Overview
<!--- Go over all the following points, and DELETE options that are not relevant. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- I have updated the inline documentation accordingly.
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online/blob/develop/CONTRIBUTING.md) document.

