### PR TITLE
Create add-new-issues-and-prs-to-project

### DIFF
--- a/.github/workflows/add-new-issues-and-prs-to-project
+++ b/.github/workflows/add-new-issues-and-prs-to-project
@@ -1,0 +1,16 @@
+name: Adds all issues to project board
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@1.0.2
+        with:
+          project-url: https://github.com/orgs/Edirom/projects/4
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description, Context and related Issue
<!--- Please describe your changes. Why is this change required? What problem does it solve? -->
Sometimes new issues and PRs are not tracked in the project view, because the "edirom development" project is not assigned.
This adds "edirom development" project automatically when a new issue or PR is opened

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Refs #591

## Types of changes
<!--- What types of changes does your code introduce? Please DELETE options that are not relevant. -->
- Improvement
