### PR TITLE
substitute builder in Dockerfiles

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -10,7 +10,7 @@
 # 1. Build Environment
 #########################
 
-FROM openjdk:8-jre-slim as builder
+FROM adoptopenjdk:8-jdk-hotspot as builder
 
 ARG ANT_VERSION=1.10.12
 ARG SOURCE=https://github.com/Edirom/Edirom-Online-Backend.git

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,7 +10,7 @@
 # 1. Build Environment
 #########################
 
-FROM openjdk:8-jre-slim as builder
+FROM adoptopenjdk:8-jdk-hotspot as builder
 
 ARG ANT_VERSION=1.10.12
 ARG SOURCE=https://github.com/Edirom/Edirom-Online-Frontend.git


### PR DESCRIPTION
## Description, Context and related Issue
This is a quick fix to issue #616. I substituted the openjdk:8-jre-slim image with adoptopenjdk:8-jdk-hotspot.
However adoptopenjdk is also deprecated and has vulnerabilities and might soon be removed from dockerhub.

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Refs #616

## How Has This Been Tested?
I run the installation guide on my machine (Windows system, Docker desktop through WSL).

## Types of changes
<!--- What types of changes does your code introduce? Please DELETE options that are not relevant. -->
- Bug fix (non-breaking change which fixes an issue)

## Overview
<!--- Go over all the following points, and DELETE options that are not relevant. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online/blob/develop/CONTRIBUTING.md) document.
