### PR TITLE
Ftr 650 document css overrides pref additional css path

### DIFF
--- a/docs/customize.md
+++ b/docs/customize.md
@@ -23,12 +23,12 @@ change the **layout** for annotations (3 are predefined), using predefined [pref
 * `<entry key="annotation_layout" value="EdiromOnline.view.window.annotationLayouts.AnnotationLayout1"/>`
 
 ## CSS
-Add a **custom CSS file**, using predefined [preferences]
+Add a **custom CSS file**, using predefined edition preferences
 * `<entry key="additional_css_path" value="xmldb:exist:///db/apps/edirom/edition-example/custom/style.css"/>`
 
 For this to work, make sure that:
-* the path to the edition's preferences file is correctly provided in the edition file - see an example for the [preferences file path in the EditionExample edition file](https://github.com/Edirom/EditionExample/blob/v0.2.0/content/ediromEditions/edirom_edition_example.xml#L8).
-* the directory path for the edition (part after `xmldb:exist:///db/apps/`, in the example this is `edirom/edition-example`) is correctly set in the [target info given in repo.xml](https://github.com/Edirom/EditionExample/blob/v0.2.0/repo.xml#L10)
+* the path to the edition's preferences file is correctly provided in your edition file - see an example for the [preferences file path in the EditionExample edition file](https://github.com/Edirom/EditionExample/blob/v0.2.0/content/ediromEditions/edirom_edition_example.xml#L8).
+* the directory path for the edition (part after `xmldb:exist:///db/apps/`, in the example this is `/edirom/edition-example`) is correctly set in the [target info given in repo.xml](https://github.com/Edirom/EditionExample/blob/v0.2.0/repo.xml#L10)
 * the relative path to the custom CSS file is correct (in the example above the last part of the URI: `custom/style.css`)
 
 

--- a/docs/customize.md
+++ b/docs/customize.md
@@ -24,7 +24,13 @@ change the **layout** for annotations (3 are predefined), using predefined [pref
 
 ## CSS
 Add a **custom CSS file**, using predefined [preferences]
-* `<entry key="additional_css_path" value="xmldb:exist:///db/apps/baudiData/editions/baudi-14-2b84beeb/edirom/css/style.css"/>`
+* `<entry key="additional_css_path" value="xmldb:exist:///db/apps/edirom/edition-example/custom/style.css"/>`
+
+For this to work, make sure that:
+* the path to the edition's preferences file is correctly provided in the edition file - see an example for the [preferences file path in the EditionExample edition file](https://github.com/Edirom/EditionExample/blob/v0.2.0/content/ediromEditions/edirom_edition_example.xml#L8).
+* the directory path for the edition (part after `xmldb:exist:///db/apps/`, in the example this is `edirom/edition-example`) is correctly set in the [target info given in repo.xml](https://github.com/Edirom/EditionExample/blob/v0.2.0/repo.xml#L10)
+* the relative path to the custom CSS file is correct (in the example above the last part of the URI: `custom/style.css`)
+
 
 ## Image server ###
 **switch the image server** from digilib to openseadragon (IIIF), using predefined [preferences]


### PR DESCRIPTION
## Description, Context and related Issue
<!--- Please describe your changes. Why is this change required? What problem does it solve? -->
The possibility to add custom CSS needed some clarification. It's not so easy to figure out the connected files in the edition, but this makes it more understandable, I hope.

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Refs #650 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
This can be tested by following und trying to understand the steps in the docs/customize.md
Have tested the steps in the EditionExample by 
* adding custom/style.css with content: `#navigator .navigatorItem { font-weight: bold; color: #f00; }`  
* adding this to the EditionExample's prefs.xml: `<entry key="additional_css_path" value="xmldb:exist:///db/apps/edirom/edition-example/custom/style.css"/>`
* then built and deployed

## Types of changes
<!--- What types of changes does your code introduce? Please DELETE options that are not relevant. -->
- Documentation Update
