### PR TITLE
Ftr 660 add GitHub api token to fair software check

### DIFF
--- a/.github/workflows/fair-software.yml
+++ b/.github/workflows/fair-software.yml
@@ -1,12 +1,6 @@
 name: fair-software
 
-# trigger when either a push to main or a new tag starting with 'v' is created
-on:
-  push:
-    branches:
-      - main
-    tags:
-      - 'v*'
+on: push
 
 jobs:
   verify:

--- a/.github/workflows/fair-software.yml
+++ b/.github/workflows/fair-software.yml
@@ -1,16 +1,37 @@
+# Adapted from https://github.com/fair-software/howfairis-github-action
+# License: Apache License 2.0
+
 name: fair-software
 
-on: push
+# This workflow is triggered on pushes to the main branch and on tags starting with 'v'.
+on:
+  push:
+    branches:
+      - main
+  tag:
+    - 'v*'
 
 jobs:
   verify:
     name: "fair-software"
     runs-on: ubuntu-latest
     steps:
+      - name: Check GitHub API rate limit (with APIKEY_GITHUB)
+        shell: bash
+        env:
+          APIKEY_GITHUB: ${{ secrets.VIFEBOTS_GITHUB_TOKEN }} # format: user:token
+        run: |
+          USERNAME="${APIKEY_GITHUB%%:*}"
+          TOKEN="${APIKEY_GITHUB#*:}"
+
+          echo "Checking as user: $USERNAME"
+          curl -sS -u "$USERNAME:$TOKEN" https://api.github.com/rate_limit \
+            | jq '.resources.core, .rate'
+
       - uses: fair-software/howfairis-github-action@0.2.1
         name: Measure compliance with fair-software.eu recommendations
         env:
           PYCHARM_HOSTED: "Trick colorama into displaying colored output" 
-          APIKEY_GITHUB: "someuser:${{ secrets.VIFEBOTS_GITHUB_TOKEN }}"
+          APIKEY_GITHUB: "vifebot:${{ secrets.VIFEBOTS_GITHUB_TOKEN }}"
         with:
           MY_REPO_URL: "https://github.com/${{ github.repository }}"

--- a/.github/workflows/fair-software.yml
+++ b/.github/workflows/fair-software.yml
@@ -11,6 +11,6 @@ jobs:
         name: Measure compliance with fair-software.eu recommendations
         env:
           PYCHARM_HOSTED: "Trick colorama into displaying colored output" 
-          APIKEY_GITHUB: "vifebot:${{ secrets.VIFEBOTS_GITHUB_TOKEN }}"
+          APIKEY_GITHUB: "someuser:${{ secrets.VIFEBOTS_GITHUB_TOKEN }}"
         with:
           MY_REPO_URL: "https://github.com/${{ github.repository }}"

--- a/.github/workflows/fair-software.yml
+++ b/.github/workflows/fair-software.yml
@@ -8,8 +8,8 @@ on:
   push:
     branches:
       - main
-  tags:
-    - 'v*'
+    tags:
+      - 'v*'
 
 jobs:
   verify:

--- a/.github/workflows/fair-software.yml
+++ b/.github/workflows/fair-software.yml
@@ -16,22 +16,10 @@ jobs:
     name: "fair-software"
     runs-on: ubuntu-latest
     steps:
-      - name: Check GitHub API rate limit (with APIKEY_GITHUB)
-        shell: bash
-        env:
-          APIKEY_GITHUB: ${{ secrets.VIFEBOTS_GITHUB_TOKEN }} # format: user:token
-        run: |
-          USERNAME="${APIKEY_GITHUB%%:*}"
-          TOKEN="${APIKEY_GITHUB#*:}"
-
-          echo "Checking as user: $USERNAME"
-          curl -sS -u "$USERNAME:$TOKEN" https://api.github.com/rate_limit \
-            | jq '.resources.core, .rate'
-
       - uses: fair-software/howfairis-github-action@0.2.1
         name: Measure compliance with fair-software.eu recommendations
         env:
           PYCHARM_HOSTED: "Trick colorama into displaying colored output" 
-          APIKEY_GITHUB: "vifebot:${{ secrets.VIFEBOTS_GITHUB_TOKEN }}"
+          APIKEY_GITHUB: "${{ github.actor }}:${{ secrets.VIFEBOTS_GITHUB_TOKEN }}"
         with:
           MY_REPO_URL: "https://github.com/${{ github.repository }}"

--- a/.github/workflows/fair-software.yml
+++ b/.github/workflows/fair-software.yml
@@ -1,6 +1,12 @@
 name: fair-software
 
-on: push
+# trigger when either a push to main or a new tag starting with 'v' is created
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
 
 jobs:
   verify:
@@ -11,5 +17,6 @@ jobs:
         name: Measure compliance with fair-software.eu recommendations
         env:
           PYCHARM_HOSTED: "Trick colorama into displaying colored output" 
+          APIKEY_GITHUB: "vifebot:${{ secrets.VIFEBOTS_GITHUB_TOKEN }}"
         with:
           MY_REPO_URL: "https://github.com/${{ github.repository }}"

--- a/.github/workflows/fair-software.yml
+++ b/.github/workflows/fair-software.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+      - 'release/**'
     tags:
       - 'v*'
 

--- a/.github/workflows/fair-software.yml
+++ b/.github/workflows/fair-software.yml
@@ -4,12 +4,12 @@
 name: fair-software
 
 # This workflow is triggered on pushes to the main branch and on tags starting with 'v'.
-on:
-  push:
-    branches:
-      - main
-  tag:
-    - 'v*'
+on: push
+#  push:
+#    branches:
+#      - main
+#  tags:
+#    - 'v*'
 
 jobs:
   verify:

--- a/.github/workflows/fair-software.yml
+++ b/.github/workflows/fair-software.yml
@@ -4,12 +4,12 @@
 name: fair-software
 
 # This workflow is triggered on pushes to the main branch and on tags starting with 'v'.
-on: push
-#  push:
-#    branches:
-#      - main
-#  tags:
-#    - 'v*'
+on: 
+  push:
+    branches:
+      - main
+  tags:
+    - 'v*'
 
 jobs:
   verify:


### PR DESCRIPTION
## Description, Context and related Issue
<!--- Please describe your changes. Why is this change required? What problem does it solve? -->
This adds the API key and restricts the run of the action to pushes on main branch or tags starting with "v*", i.e. version tags

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Refs #660 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
ran it on several test pushes

## Types of changes
<!--- What types of changes does your code introduce? Please DELETE options that are not relevant. -->
- Improvement

## Overview
<!--- Go over all the following points, and DELETE options that are not relevant. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- I have updated the inline documentation accordingly.
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online/blob/develop/CONTRIBUTING.md) document.
- I have added tests to cover my changes at [testing](https://github.com/Edirom/Edirom-Online/tree/develop/testing)
- All new and existing tests passed.
